### PR TITLE
feat: updated validator functions for Multiflash

### DIFF
--- a/api/src/entities/Multiflash.py
+++ b/api/src/entities/Multiflash.py
@@ -18,46 +18,45 @@ class Multiflash(BaseModel):
     Model for the computing multiphase flash calculation input.
     """
 
-    number_of_components: int = Field(
-        ..., description="Number of components to process", gt=0
-    )  # unnecessary: len(component_ids)?
     component_ids: List[int] = Field(..., description="The id's of the components (e.g. H2O, Hg, ...) to process")
     temperature: float = Field(..., description="Temperature (in Celsius) for computation", gt=-273.15)
     pressure: float = Field(..., description="Pressure (in bar) for computation")
-    composition: List[float] = Field(..., description="")  # feed_composition?
+    feed_composition: List[float] = Field(..., description="The percentage of each component in the feed")
 
     class Config:
         allow_mutation = False
         schema_extra = {
             "example": {
-                "number_of_components": 5,
                 "component_ids": [1, 2, 3, 1001, 5],
                 "temperature": 37,
                 "pressure": 20,
-                "composition": [0.98348, 0.09, 0.0247, 0.4565, 0.067685],
+                "feed_composition": [0.98348, 0.09, 0.0247, 0.4565, 0.067685],
             }
         }
 
     @validator("component_ids")
-    def validate_component_ids(cls, v, values):
-        # TODO: Possible to validate each ID against table (currently not possible as test data includes other components)
-        if len(v) != values["number_of_components"]:
-            raise ValueError("Length of component_ids must match number_of_components.")
+    def validate_component_ids(cls, v):
+        # TODO: validates each ID against COMPONENT_IDS (currently not possible as test data includes other components)
+        # if not set(v) < set(COMPONENT_IDS.keys()):
+        #     raise ValueError("component_id input contains unknown component!")
         return v
 
-    @validator("composition")
+    @validator("feed_composition")
     def validate_composition(cls, v, values):
-        if len(v) != values["number_of_components"]:
-            raise ValueError("Length of composition must match number_of_components.")
+        if len(v) != len(values["component_ids"]):
+            raise ValueError("composition list must be of same length as component_ids")
+        # TODO: Tolerance?
+        if sum(v) - 1 > 0.05:
+            raise ValueError("composition list should add to approx. 1")
         return v
 
     def compute(self) -> MultiflashResult:
         phase_label, phase_fraction, moles = libhg.compute_multiflash(
-            num_comp=self.number_of_components,
+            num_comp=len(self.component_ids),
             components=self.component_ids,
             temperature=self.temperature,
             pressure=self.pressure,
-            feed_composition=self.composition,
+            feed_composition=self.feed_composition,
         )
         # convert phase_label from list[list[bytes]] to list[str] and remove empty strings:
         new_phase_label = list(filter(None, [entry.tobytes().decode("utf-8").strip() for entry in phase_label]))

--- a/api/src/tests/test_data/multiflash_input.json
+++ b/api/src/tests/test_data/multiflash_input.json
@@ -28,7 +28,7 @@
    ],
    "temperature":20,
    "pressure":21,
-   "composition":[
+   "feed_composition":[
       0.173798348,
       0.0039,
       0.0247,

--- a/api/src/tests/unit/entities/test_multiflash.py
+++ b/api/src/tests/unit/entities/test_multiflash.py
@@ -8,42 +8,37 @@ from entities.Multiflash import Multiflash, MultiflashResult
 
 def test_multiflash_init():
     multiflash = Multiflash(
-        number_of_components=5,
         component_ids=[1, 2, 3, 4, 1001],
         temperature=9001,
         pressure=9001,
-        composition=[0.1, 0.2, 0.3, 0.4, 0.5],
+        feed_composition=[0.1, 0.2, 0.3, 0.2, 0.2],
     )
-    assert multiflash.number_of_components == 5
     assert multiflash.component_ids == [1, 2, 3, 4, 1001]
     assert multiflash.temperature > 9000
     assert multiflash.pressure > 9000
-    assert multiflash.composition == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert multiflash.feed_composition == [0.1, 0.2, 0.3, 0.2, 0.2]
 
 
 def test_multiflash_from_dict():
     init_dict = {
-        "number_of_components": 5,
         "component_ids": [1, 2, 3, 4, 1001],
         "temperature": 9001,
         "pressure": 9001,
-        "composition": [0.1, 0.2, 0.3, 0.4, 0.5],
+        "feed_composition": [0.1, 0.2, 0.3, 0.2, 0.2],
     }
     multiflash = Multiflash(**init_dict)
-    assert multiflash.number_of_components == 5
     assert multiflash.component_ids == [1, 2, 3, 4, 1001]
     assert multiflash.temperature > 9000
     assert multiflash.pressure > 9000
-    assert multiflash.composition == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert multiflash.feed_composition == [0.1, 0.2, 0.3, 0.2, 0.2]
 
 
 def test_multiflash_comparison():
     init_dict = {
-        "number_of_components": 5,
         "component_ids": [1, 2, 3, 4, 1001],
         "temperature": 9001,
         "pressure": 9001,
-        "composition": [0.1, 0.2, 0.3, 0.4, 0.5],
+        "feed_composition": [0.1, 0.2, 0.3, 0.2, 0.2],
     }
     multiflash_1 = Multiflash(**init_dict)
     multiflash_2 = Multiflash(**init_dict)


### PR DESCRIPTION
## Why is this pull request needed?

Component length is not necessary to instantiate Multiflash. This is removed, necessitating an update of the validator functions.

## Issues related to this change:

The test data we currently have has some components outside of the list of common.components.COMPONENT_IDS and therefore the validation of component_ids has to be turned off for the time being.

closes #29 