### PR TITLE
fix: add arg for git hash

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
        # Caches the venv at the end of the job and reloads for quicker pre-commit.
        # Uses pyproject.toml and pre-commit-config file to create hash.
       - name: Cache venv
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.8
         id: cache
         with:
           path: |

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,13 +23,14 @@ ENV PATH="/opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64:$PATH" \
 # Clone libhg fortran repo
 FROM dependencies as build
 ARG LIBHG_REPO_DEPLOY_KEY
+ENV GITHASH=90e7c74978ef8984306d2878dfef4a56dd2b1d2f
 RUN mkdir /root/.ssh && echo "$LIBHG_REPO_DEPLOY_KEY" > /root/.ssh/id_ed25519
 RUN chmod -R 600 /root/.ssh
 RUN ssh-keyscan github.com > ~/.ssh/known_hosts
 RUN git clone git@github.com:equinor/gpa-libhg.git
 
 # Pulls latest stabile commit from libhg repository:
-RUN git -C gpa-libhg checkout 90e7c74978ef8984306d2878dfef4a56dd2b1d2f
+RUN git -C gpa-libhg checkout $GITHASH
 RUN mv gpa-libhg/libhg ./libhg
 
 # Compile fortran library and create python .so file


### PR DESCRIPTION
## Why is this pull request needed?

To ensure the flow of cloning and checking out always happens correctly. Previously, changing the git sha in checkout did not update the cloning (caching) leading to not found commit sha.