### PR TITLE
Fix/ci tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,19 +30,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
 
-       # Caches the venv at the end of the job and reloads for quicker pre-commit.
-       # Uses pyproject.toml and pre-commit-config file to create hash.
-      - name: Cache venv
-        uses: actions/cache@v3.0.8
-        id: cache
-        with:
-          path: |
-            ~/work/mercury/mercury/api/.venv
-            ~/.cache/pre-commit
-          key: venv-${{ runner.os }}-${{ hashFiles('api/pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
       - name: Set up venv
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install poetry
           poetry config virtualenvs.in-project true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
        # Caches the venv at the end of the job and reloads for quicker pre-commit.
        # Uses pyproject.toml and pre-commit-config file to create hash.
       - name: Cache venv
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.8
         id: cache
         with:
           path: |

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 # Installing build dependencies. Including f2py(Fortan to python, included in numpy)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl ca-certificates gnupg2 git openssh-client && \
+    curl ca-certificates gnupg2 git openssh-client procps && \
     pip install numpy=="1.23.0"
 
 # Install Intel Fortran compiler
@@ -16,25 +16,23 @@ RUN apt-get update && \
     build-essential openssh-client intel-oneapi-compiler-fortran && \
     rm -rf /var/lib/apt/lists/*
 
-# Set environment variables
-ENV PATH="/opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64:$PATH" \
-    LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2022.1.0/linux/lib:/opt/intel/oneapi/compiler/2022.1.0/linux/lib/x64:/opt/intel/oneapi/compiler/2022.1.0/linux/compiler/lib/intel64_lin"
-
 # Clone libhg fortran repo
 FROM dependencies as build
 ARG LIBHG_REPO_DEPLOY_KEY
+ENV GITHASH=90e7c74978ef8984306d2878dfef4a56dd2b1d2f
 RUN mkdir /root/.ssh && echo "$LIBHG_REPO_DEPLOY_KEY" > /root/.ssh/id_ed25519
 RUN chmod -R 600 /root/.ssh
 RUN ssh-keyscan github.com > ~/.ssh/known_hosts
 RUN git clone git@github.com:equinor/gpa-libhg.git
 
 # Pulls latest stabile commit from libhg repository:
-RUN git -C gpa-libhg checkout 90e7c74978ef8984306d2878dfef4a56dd2b1d2f
+RUN git -C gpa-libhg checkout $GITHASH
 RUN mv gpa-libhg/libhg ./libhg
 
-# Compile fortran library and create python .so file
+# Load env variables, compile fortran library and create python .so file
+SHELL ["/bin/bash", "-c"]
 COPY compile.sh ./libhg/
-RUN cd libhg && ./compile.sh
+RUN cd libhg && source /opt/intel/oneapi/setvars.sh && ./compile.sh
 
 FROM python:3.10-slim as base
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because ci was unstable.

## What does this pull request change?

Environmental variables for ifort is set by shell script provided by intel oneapi.
Add githash variable before clone to ensure docker caching works when git hash is updated.
Pre-commit caching is disabled (very unstable).