### PR TITLE
feat: add feed unit input and switch

### DIFF
--- a/web/src/components/feature/FeedFlowInput.tsx
+++ b/web/src/components/feature/FeedFlowInput.tsx
@@ -1,0 +1,38 @@
+import { Switch, TextField } from '@equinor/eds-core-react'
+import styled from 'styled-components'
+import { TFeedUnit } from './PhaseTable'
+
+const FlexContainer = styled.div`
+  display: flex;
+  gap: 16px;
+`
+
+export const FeedFlowInput = (props: {
+  feedFlow: number
+  feedUnit: TFeedUnit
+  setFeedFlow: (value: number) => void
+  setFeedUnit: (unit: TFeedUnit) => void
+}) => {
+  return (
+    <FlexContainer>
+      <TextField
+        id="feed-flow-input"
+        value={props.feedFlow.toString()}
+        label="Feed Flow"
+        unit={props.feedUnit}
+        type="number"
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          props.setFeedFlow(Number(event.target.value))
+        }
+      />
+      <Switch
+        label="Feed unit"
+        size="small"
+        checked={props.feedUnit === 'kg/d'}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          props.setFeedUnit(event.target.checked ? 'kg/d' : 'Sm3/d')
+        }
+      />
+    </FlexContainer>
+  )
+}

--- a/web/src/components/feature/PhaseTable.tsx
+++ b/web/src/components/feature/PhaseTable.tsx
@@ -1,11 +1,24 @@
 import { DynamicTable } from '../common/DynamicTable'
 import { MultiflashResponse } from '../../api/generated'
+import styled from 'styled-components'
+import { FeedFlowInput } from './FeedFlowInput'
+import { useState } from 'react'
+
+export type TFeedUnit = 'kg/d' | 'Sm3/d'
+
+const PhaseTableContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+  max-width: 500px;
+`
 
 function getRows(
   multiFlashResponse: MultiflashResponse,
-  cubicFeedFlow: number
+  feedFlow: number
 ): string[][] {
-  const phPhaseFlowFactor = cubicFeedFlow * 42.29256 * 200.59
+  // TODO: Assumes feed flow unit is Sm3/d
+  const phPhaseFlowFactor = feedFlow * 42.29256 * 200.59
   const mercury = multiFlashResponse.componentFractions['5']
   return Object.entries(multiFlashResponse.phaseValues).map(
     ([phase, values], index) => [
@@ -20,20 +33,29 @@ function getRows(
 
 export const PhaseTable = (props: {
   multiFlashResponse: MultiflashResponse
-  cubicFeedFlow: number
 }) => {
-  const { multiFlashResponse, cubicFeedFlow } = props
+  const [feedFlow, setFeedFlow] = useState(1000)
+  const [feedUnit, setFeedUnit] = useState('Sm3/d' as TFeedUnit)
+
   return (
-    <DynamicTable
-      headers={[
-        'Phases',
-        'Ratio',
-        'Mass Concentration',
-        'Mole Concentration',
-        'Mercury Flow (g/d)',
-      ]}
-      rows={getRows(multiFlashResponse, cubicFeedFlow)}
-      density={'comfortable'}
-    />
+    <PhaseTableContainer>
+      <FeedFlowInput
+        feedFlow={feedFlow}
+        feedUnit={feedUnit}
+        setFeedFlow={setFeedFlow}
+        setFeedUnit={setFeedUnit}
+      />
+      <DynamicTable
+        headers={[
+          'Phases',
+          'Ratio',
+          'Mass Concentration',
+          'Mole Concentration',
+          'Mercury Flow (g/d)',
+        ]}
+        rows={getRows(props.multiFlashResponse, feedFlow)}
+        density={'comfortable'}
+      />
+    </PhaseTableContainer>
   )
 }

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -50,9 +50,6 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
       .finally(() => setIsLoading(false))
   }, [mercuryApi])
 
-  // TODO: get value from input
-  const cubicFeedFlow = 1000
-
   if (isLoading) return <></>
 
   // TODO: Better error handling and message
@@ -66,10 +63,7 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
         <ComponentSelector components={components} />
         <DividerWithLargeSpacings />
         <Results>
-          <PhaseTable
-            multiFlashResponse={result}
-            cubicFeedFlow={cubicFeedFlow}
-          />
+          <PhaseTable multiFlashResponse={result} />
           <MoleTable multiFlashResponse={result} components={components} />
         </Results>
       </Container>


### PR DESCRIPTION
## Why is this pull request needed?

In order to compute the PhaseTable component, it is necessary to have a number for the feed flow (this is input, but not input to the Fortran code). The feed flow can be given as in Sm3/d or kg/d depending on which information the user has available, therefore there is a switch to change units.

## What does this pull request change?

Add a text field and a switch.

## Issues related to this change:
Closes #73
