### PR TITLE
tests: move constants out of tests

### DIFF
--- a/web/src/components/feature/MoleTable.test.tsx
+++ b/web/src/components/feature/MoleTable.test.tsx
@@ -1,77 +1,19 @@
 import { render, screen } from '@testing-library/react'
 import { MoleTable } from './MoleTable'
 import '@testing-library/jest-dom/extend-expect'
-import { ComponentResponse, MultiflashResponse } from '../../api/generated'
-
-const testComponents: ComponentResponse = {
-  components: {
-    '1': { chemicalFormula: 'CO2', altName: 'Carbondioxide' },
-    '2': { chemicalFormula: 'N2', altName: 'Nitrogen' },
-    '3': { chemicalFormula: 'H2O', altName: 'Water' },
-    '4': { chemicalFormula: 'H2S', altName: 'Hydrogensulfide' },
-    '5': { chemicalFormula: 'Hg', altName: 'Mercury' },
-    '101': { chemicalFormula: 'CH4', altName: 'Methane' },
-    '201': { chemicalFormula: 'C2H6', altName: 'Ethane' },
-    '301': { chemicalFormula: 'nC3', altName: 'Propane' },
-    '401': { chemicalFormula: 'iC4', altName: 'i-Butane' },
-    '402': { chemicalFormula: 'nC4', altName: 'n-Butane' },
-    '501': { chemicalFormula: '22-dm-C3', altName: '2-2-dimethyl-propane' },
-    '503': { chemicalFormula: 'iC5', altName: 'i-Pentane' },
-    '504': { chemicalFormula: 'nC5', altName: 'n-Pentane' },
-    '502': { chemicalFormula: 'cy-C5', altName: 'Cy-C5' },
-    '601': {
-      chemicalFormula: '22-dm-C4',
-      altName: '2-2-dimethyl-butane(neohexane)',
-    },
-    '602': { chemicalFormula: '23-dm-C4', altName: '2-3-dimethyl-butane' },
-    '603': { chemicalFormula: '2-m-C5', altName: '2-methyl-pentane' },
-    '604': { chemicalFormula: '3-m-C5', altName: '3-methyl-pentane' },
-    '605': { chemicalFormula: 'nC6', altName: 'n-Hexane' },
-    '606': { chemicalFormula: 'cy-C6', altName: 'Cy-hexane' },
-    '608': { chemicalFormula: 'benzene', altName: 'Benzene' },
-    '701': { chemicalFormula: 'nC7', altName: 'n-heptane' },
-    '707': { chemicalFormula: 'cy-C7', altName: 'Cy-heptane' },
-    '710': { chemicalFormula: 'toluene', altName: 'Toluene' },
-    '801': { chemicalFormula: 'nC8', altName: 'n-octane' },
-    '806': { chemicalFormula: 'cy-C8', altName: 'Cy-octane' },
-    '809': { chemicalFormula: 'm-xylene', altName: 'M-xylene' },
-    '901': { chemicalFormula: 'nC9', altName: 'n-nonane' },
-    '1016': { chemicalFormula: 'nC10', altName: 'n-decane' },
-  },
-}
-
-const testMultiflashResult: MultiflashResponse = {
-  phaseValues: {
-    Vapor: { percentage: 0.9989992588, mercury: 104.82781237 },
-    Mercury: { percentage: 0.0010007412, mercury: 1000000000.0 },
-  },
-  componentFractions: {
-    2: [0.01693, 0.000000000000000000000003431],
-    1: [0.05399, 0.000000000000000000000006807],
-    101: [0.8563, 0.0000000000000000000001379],
-    201: [0.04577, 0.00000000000000000000000481],
-    301: [0.01763, 0.000000000000000000000001301],
-    401: [0.002424, 0.0000000000000000000000001389],
-    402: [0.004378, 0.0000000000000000000000002324],
-    503: [0.001212, 0.00000000000000000000000005006],
-    504: [0.001102, 0.00000000000000000000000004238],
-    608: [0.0001473, 0.000000000000000000000000005109],
-    710: [0.00008415, 0.000000000000000000000000002175],
-    809: [0.00002304, 0.000000000000000000000000000433],
-    5: [0.00000001236, 1.0],
-  },
-  feedMolecularWeight: 5,
-}
+import { mockComponentResponse, mockMultiflashResponse } from '../../setupTests'
 
 test('renders without crashing and displaying correct values in table', async () => {
   render(
     <MoleTable
-      components={testComponents}
-      multiFlashResponse={testMultiflashResult}
+      components={mockComponentResponse}
+      multiFlashResponse={mockMultiflashResponse}
     />
   )
   // @ts-ignore because not able to get eslint to discover these types
-  expect(screen.getByTestId('Vapor-0')).toHaveTextContent('0.05399')
+  expect(screen.getByTestId('Vapor-0')).toHaveTextContent('0.0487818478493959')
   // @ts-ignore because not able to get eslint to discover these types
-  expect(screen.getByTestId('Mercury-7')).toHaveTextContent('2.324e-25')
+  expect(screen.getByTestId('Mercury-7')).toHaveTextContent(
+    '1.5028484039426094e-24'
+  )
 })

--- a/web/src/components/feature/PhaseTable.test.tsx
+++ b/web/src/components/feature/PhaseTable.test.tsx
@@ -1,39 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import { PhaseTable } from './PhaseTable'
 import '@testing-library/jest-dom/extend-expect'
-import { MultiflashResponse } from '../../api/generated'
-
-const multiflashResult: MultiflashResponse = {
-  phaseValues: {
-    Vapor: { percentage: 0.9989992588, mercury: 104.82781237 },
-    Mercury: { percentage: 0.0010007412, mercury: 1000000000.0 },
-  },
-  componentFractions: {
-    2: [0.01693, 0.000000000000000000000003431],
-    1: [0.05399, 0.000000000000000000000006807],
-    101: [0.8563, 0.0000000000000000000001379],
-    201: [0.04577, 0.00000000000000000000000481],
-    301: [0.01763, 0.000000000000000000000001301],
-    401: [0.002424, 0.0000000000000000000000001389],
-    402: [0.004378, 0.0000000000000000000000002324],
-    503: [0.001212, 0.00000000000000000000000005006],
-    504: [0.001102, 0.00000000000000000000000004238],
-    608: [0.0001473, 0.000000000000000000000000005109],
-    710: [0.00008415, 0.000000000000000000000000002175],
-    809: [0.00002304, 0.000000000000000000000000000433],
-    5: [0.00000001236, 1.0],
-  },
-  feedMolecularWeight: 5,
-}
+import { mockMultiflashResponse } from '../../setupTests'
 
 test('renders without crashing and displaying correct values in table', async () => {
-  render(<PhaseTable multiFlashResponse={multiflashResult} />)
+  render(<PhaseTable multiFlashResponse={mockMultiflashResponse} />)
   // @ts-ignore because not able to get eslint to discover these types
   expect(screen.getByTestId('Mass Concentration-0')).toHaveTextContent(
-    '104.82781237'
+    '9576.977265669584'
   )
   // @ts-ignore because not able to get eslint to discover these types
-  expect(screen.getByTestId('Mole Concentration-1')).toHaveTextContent('1')
+  expect(screen.getByTestId('Mole Concentration-2')).toHaveTextContent('1')
   // @ts-ignore because not able to get eslint to discover these types
   expect(screen.getByTestId('Phases-0')).toHaveTextContent('Vapor')
 })

--- a/web/src/pages/Main.test.tsx
+++ b/web/src/pages/Main.test.tsx
@@ -2,102 +2,18 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { MainPage } from './Main'
 import MercuryAPI from '../api/MercuryAPI'
-import { ComponentResponse, MultiflashResponse } from '../api/generated'
 import { AxiosResponse } from 'axios'
+import { mockComponentResponse, mockMultiflashResponse } from '../setupTests'
 
 test('renders without crashing and calculate run populates tables', async () => {
   const mockMercuryApi = new MercuryAPI()
-  const multiflashResponse: MultiflashResponse = {
-    phaseValues: {
-      Vapor: {
-        percentage: 0.9530398821754837,
-        mercury: 9576.977265669584,
-      },
-      Aqueous: {
-        percentage: 0.04596219288894959,
-        mercury: 42.95333958603203,
-      },
-      Mercury: {
-        percentage: 0.0009979249355665074,
-        mercury: 1000000000,
-      },
-    },
-    componentFractions: {
-      '1': [0.0487818478493959, 0.00003178625137356113, 9.357933137511921e-24],
-      '2': [0.004926658586182084, 5.606370638941071e-8, 9.521979777029961e-25],
-      '3': [0.016978518176734285, 0.999923029961448, 3.2368004598608978e-24],
-      '5': [0.0000011288993580273517, 3.858025869444538e-9, 1.0000000000000002],
-      '101': [
-        0.6851613143677305, 0.00002077078423705684, 1.319319561831917e-22,
-      ],
-      '201': [
-        0.09046902819956745, 0.000004073890325362129, 1.7297094356248018e-23,
-      ],
-      '301': [
-        0.047759949263746916, 0.000007530068352386529, 9.075924729973352e-24,
-      ],
-      '401': [
-        0.007944465811905398, 7.791208565250264e-7, 1.5028484039426094e-24,
-      ],
-      '402': [
-        0.016227467901725096, 0.0000024012881239653258, 3.0664046159226887e-24,
-      ],
-      '503': [
-        0.005438171625943571, 4.946930604181399e-7, 1.0230429071522505e-24,
-      ],
-      '504': [
-        0.006415100362966198, 8.620089341914816e-7, 1.2054916829998997e-24,
-      ],
-      '605': [
-        0.06989634895474478, 0.000008212011556262026, 1.3063098591813244e-23,
-      ],
-    },
-    feedMolecularWeight: 26.494307395,
-  }
-
-  const components: ComponentResponse = {
-    components: {
-      '1': { chemicalFormula: 'CO2', altName: 'Carbondioxide' },
-      '2': { chemicalFormula: 'N2', altName: 'Nitrogen' },
-      '3': { chemicalFormula: 'H2O', altName: 'Water' },
-      '4': { chemicalFormula: 'H2S', altName: 'Hydrogensulfide' },
-      '5': { chemicalFormula: 'Hg', altName: 'Mercury' },
-      '101': { chemicalFormula: 'CH4', altName: 'Methane' },
-      '201': { chemicalFormula: 'C2H6', altName: 'Ethane' },
-      '301': { chemicalFormula: 'nC3', altName: 'Propane' },
-      '401': { chemicalFormula: 'iC4', altName: 'i-Butane' },
-      '402': { chemicalFormula: 'nC4', altName: 'n-Butane' },
-      '501': { chemicalFormula: '22-dm-C3', altName: '2-2-dimethyl-propane' },
-      '503': { chemicalFormula: 'iC5', altName: 'i-Pentane' },
-      '504': { chemicalFormula: 'nC5', altName: 'n-Pentane' },
-      '502': { chemicalFormula: 'cy-C5', altName: 'Cy-C5' },
-      '601': {
-        chemicalFormula: '22-dm-C4',
-        altName: '2-2-dimethyl-butane(neohexane)',
-      },
-      '602': { chemicalFormula: '23-dm-C4', altName: '2-3-dimethyl-butane' },
-      '603': { chemicalFormula: '2-m-C5', altName: '2-methyl-pentane' },
-      '604': { chemicalFormula: '3-m-C5', altName: '3-methyl-pentane' },
-      '605': { chemicalFormula: 'nC6', altName: 'n-Hexane' },
-      '606': { chemicalFormula: 'cy-C6', altName: 'Cy-hexane' },
-      '608': { chemicalFormula: 'benzene', altName: 'Benzene' },
-      '701': { chemicalFormula: 'nC7', altName: 'n-heptane' },
-      '707': { chemicalFormula: 'cy-C7', altName: 'Cy-heptane' },
-      '710': { chemicalFormula: 'toluene', altName: 'Toluene' },
-      '801': { chemicalFormula: 'nC8', altName: 'n-octane' },
-      '806': { chemicalFormula: 'cy-C8', altName: 'Cy-octane' },
-      '809': { chemicalFormula: 'm-xylene', altName: 'M-xylene' },
-      '901': { chemicalFormula: 'nC9', altName: 'n-nonane' },
-      '1016': { chemicalFormula: 'nC10', altName: 'n-decane' },
-    },
-  }
 
   mockMercuryApi.getComponents = jest.fn(() => {
-    return Promise.resolve({ data: components } as AxiosResponse)
+    return Promise.resolve({ data: mockComponentResponse } as AxiosResponse)
   })
 
   mockMercuryApi.computeMultiflash = jest.fn(() => {
-    return Promise.resolve({ data: multiflashResponse } as AxiosResponse)
+    return Promise.resolve({ data: mockMultiflashResponse } as AxiosResponse)
   })
 
   render(<MainPage mercuryApi={mockMercuryApi} />)

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -3,3 +3,81 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+import { ComponentResponse, MultiflashResponse } from './api/generated'
+
+export const mockMultiflashResponse: MultiflashResponse = {
+  phaseValues: {
+    Vapor: {
+      percentage: 0.9530398821754837,
+      mercury: 9576.977265669584,
+    },
+    Aqueous: {
+      percentage: 0.04596219288894959,
+      mercury: 42.95333958603203,
+    },
+    Mercury: {
+      percentage: 0.0009979249355665074,
+      mercury: 1000000000,
+    },
+  },
+  componentFractions: {
+    '1': [0.0487818478493959, 0.00003178625137356113, 9.357933137511921e-24],
+    '2': [0.004926658586182084, 5.606370638941071e-8, 9.521979777029961e-25],
+    '3': [0.016978518176734285, 0.999923029961448, 3.2368004598608978e-24],
+    '5': [0.0000011288993580273517, 3.858025869444538e-9, 1.0000000000000002],
+    '101': [0.6851613143677305, 0.00002077078423705684, 1.319319561831917e-22],
+    '201': [
+      0.09046902819956745, 0.000004073890325362129, 1.7297094356248018e-23,
+    ],
+    '301': [
+      0.047759949263746916, 0.000007530068352386529, 9.075924729973352e-24,
+    ],
+    '401': [0.007944465811905398, 7.791208565250264e-7, 1.5028484039426094e-24],
+    '402': [
+      0.016227467901725096, 0.0000024012881239653258, 3.0664046159226887e-24,
+    ],
+    '503': [0.005438171625943571, 4.946930604181399e-7, 1.0230429071522505e-24],
+    '504': [0.006415100362966198, 8.620089341914816e-7, 1.2054916829998997e-24],
+    '605': [
+      0.06989634895474478, 0.000008212011556262026, 1.3063098591813244e-23,
+    ],
+  },
+  feedMolecularWeight: 26.494307395,
+}
+
+export const mockComponentResponse: ComponentResponse = {
+  components: {
+    '1': { chemicalFormula: 'CO2', altName: 'Carbondioxide' },
+    '2': { chemicalFormula: 'N2', altName: 'Nitrogen' },
+    '3': { chemicalFormula: 'H2O', altName: 'Water' },
+    '4': { chemicalFormula: 'H2S', altName: 'Hydrogensulfide' },
+    '5': { chemicalFormula: 'Hg', altName: 'Mercury' },
+    '101': { chemicalFormula: 'CH4', altName: 'Methane' },
+    '201': { chemicalFormula: 'C2H6', altName: 'Ethane' },
+    '301': { chemicalFormula: 'nC3', altName: 'Propane' },
+    '401': { chemicalFormula: 'iC4', altName: 'i-Butane' },
+    '402': { chemicalFormula: 'nC4', altName: 'n-Butane' },
+    '501': { chemicalFormula: '22-dm-C3', altName: '2-2-dimethyl-propane' },
+    '503': { chemicalFormula: 'iC5', altName: 'i-Pentane' },
+    '504': { chemicalFormula: 'nC5', altName: 'n-Pentane' },
+    '502': { chemicalFormula: 'cy-C5', altName: 'Cy-C5' },
+    '601': {
+      chemicalFormula: '22-dm-C4',
+      altName: '2-2-dimethyl-butane(neohexane)',
+    },
+    '602': { chemicalFormula: '23-dm-C4', altName: '2-3-dimethyl-butane' },
+    '603': { chemicalFormula: '2-m-C5', altName: '2-methyl-pentane' },
+    '604': { chemicalFormula: '3-m-C5', altName: '3-methyl-pentane' },
+    '605': { chemicalFormula: 'nC6', altName: 'n-Hexane' },
+    '606': { chemicalFormula: 'cy-C6', altName: 'Cy-hexane' },
+    '608': { chemicalFormula: 'benzene', altName: 'Benzene' },
+    '701': { chemicalFormula: 'nC7', altName: 'n-heptane' },
+    '707': { chemicalFormula: 'cy-C7', altName: 'Cy-heptane' },
+    '710': { chemicalFormula: 'toluene', altName: 'Toluene' },
+    '801': { chemicalFormula: 'nC8', altName: 'n-octane' },
+    '806': { chemicalFormula: 'cy-C8', altName: 'Cy-octane' },
+    '809': { chemicalFormula: 'm-xylene', altName: 'M-xylene' },
+    '901': { chemicalFormula: 'nC9', altName: 'n-nonane' },
+    '1016': { chemicalFormula: 'nC10', altName: 'n-decane' },
+  },
+}


### PR DESCRIPTION
## Why is this pull request needed?

Make tests cleaner.

## What does this pull request change?

Moves constants out of tests and into setuptest.ts

## Issues related to this change:
closes #81
Not sure if this is the best way to do it, but couldn't manage to get it working with globals as in the documentation without typescript errors.