### PR TITLE
refactor: move feed flow switch below inputs

### DIFF
--- a/web/src/components/feature/CalculateFluid.tsx
+++ b/web/src/components/feature/CalculateFluid.tsx
@@ -15,6 +15,8 @@ import {
 } from '../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../api/MercuryAPI'
+import { FeedFlowInput } from './FeedFlowInput'
+import { TFeedFlow } from '../../pages/Main'
 
 const FlexContainer = styled.div`
   display: flex;
@@ -38,10 +40,14 @@ export const CalculateFluid = ({
   mercuryApi,
   setResult,
   components,
+  feedFlow,
+  setFeedFlow,
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: MultiflashResponse) => void
   components: ComponentResponse
+  feedFlow: TFeedFlow
+  setFeedFlow: (feedFlow: TFeedFlow) => void
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [temperature, setTemperature] = useState<number>(15)
@@ -139,6 +145,7 @@ export const CalculateFluid = ({
               }
             />
           </FlexContainer>
+          <FeedFlowInput feedFlow={feedFlow} setFeedFlow={setFeedFlow} />
         </Form>
       </Card>
       <FluidDialog

--- a/web/src/components/feature/FeedFlowInput.tsx
+++ b/web/src/components/feature/FeedFlowInput.tsx
@@ -1,6 +1,7 @@
 import { Switch, TextField } from '@equinor/eds-core-react'
 import styled from 'styled-components'
-import { TFeedUnit } from './PhaseTable'
+import { Card } from '../common/Card'
+import { TFeedFlow } from '../../pages/Main'
 
 const FlexContainer = styled.div`
   display: flex;
@@ -8,29 +9,31 @@ const FlexContainer = styled.div`
 `
 
 export const FeedFlowInput = (props: {
-  feedFlow: number
-  feedUnit: TFeedUnit
-  setFeedFlow: (value: number) => void
-  setFeedUnit: (unit: TFeedUnit) => void
+  feedFlow: TFeedFlow
+  setFeedFlow: (value: TFeedFlow) => void
 }) => {
   return (
     <FlexContainer>
       <TextField
         id="feed-flow-input"
-        value={props.feedFlow.toString()}
-        label="Feed Flow"
-        unit={props.feedUnit}
+        value={props.feedFlow.value.toString()}
+        unit={props.feedFlow.unit}
         type="number"
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          props.setFeedFlow(Number(event.target.value))
+          props.setFeedFlow({
+            unit: props.feedFlow.unit,
+            value: Number(event.target.value),
+          })
         }
       />
       <Switch
-        label="Feed unit"
-        size="small"
-        checked={props.feedUnit === 'kg/d'}
+        label="Unit"
+        checked={props.feedFlow.unit === 'kg/d'}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          props.setFeedUnit(event.target.checked ? 'kg/d' : 'Sm3/d')
+          props.setFeedFlow({
+            unit: event.target.checked ? 'kg/d' : 'Sm3/d',
+            value: props.feedFlow.value,
+          })
         }
       />
     </FlexContainer>

--- a/web/src/components/feature/PhaseTable.test.tsx
+++ b/web/src/components/feature/PhaseTable.test.tsx
@@ -4,7 +4,12 @@ import '@testing-library/jest-dom/extend-expect'
 import { mockMultiflashResponse } from '../../setupTests'
 
 test('renders without crashing and displaying correct values in table', async () => {
-  render(<PhaseTable multiFlashResponse={mockMultiflashResponse} />)
+  render(
+    <PhaseTable
+      multiFlashResponse={mockMultiflashResponse}
+      feedFlow={{ unit: 'Sm3/d', value: 0 }}
+    />
+  )
   // @ts-ignore because not able to get eslint to discover these types
   expect(screen.getByTestId('Mass Concentration-0')).toHaveTextContent(
     '9576.977265669584'

--- a/web/src/components/feature/PhaseTable.tsx
+++ b/web/src/components/feature/PhaseTable.tsx
@@ -1,17 +1,8 @@
 import { DynamicTable } from '../common/DynamicTable'
 import { MultiflashResponse } from '../../api/generated'
-import styled from 'styled-components'
-import { FeedFlowInput } from './FeedFlowInput'
-import { useState } from 'react'
+import { TFeedFlow } from '../../pages/Main'
 
 export type TFeedUnit = 'kg/d' | 'Sm3/d'
-
-const PhaseTableContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  row-gap: 4px;
-  max-width: 500px;
-`
 
 function getRows(
   multiFlashResponse: MultiflashResponse,
@@ -33,29 +24,19 @@ function getRows(
 
 export const PhaseTable = (props: {
   multiFlashResponse: MultiflashResponse
+  feedFlow: TFeedFlow
 }) => {
-  const [feedFlow, setFeedFlow] = useState(1000)
-  const [feedUnit, setFeedUnit] = useState('Sm3/d' as TFeedUnit)
-
   return (
-    <PhaseTableContainer>
-      <FeedFlowInput
-        feedFlow={feedFlow}
-        feedUnit={feedUnit}
-        setFeedFlow={setFeedFlow}
-        setFeedUnit={setFeedUnit}
-      />
-      <DynamicTable
-        headers={[
-          'Phases',
-          'Ratio',
-          'Mass Concentration',
-          'Mole Concentration',
-          'Mercury Flow (g/d)',
-        ]}
-        rows={getRows(props.multiFlashResponse, feedFlow)}
-        density={'comfortable'}
-      />
-    </PhaseTableContainer>
+    <DynamicTable
+      headers={[
+        'Phases',
+        'Ratio',
+        'Mass Concentration',
+        'Mole Concentration',
+        'Mercury Flow (g/d)',
+      ]}
+      rows={getRows(props.multiFlashResponse, props.feedFlow.value)}
+      density={'comfortable'}
+    />
   )
 }

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -7,7 +7,7 @@ import { CalculateFluid } from '../components/feature/CalculateFluid'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
-import { PhaseTable } from '../components/feature/PhaseTable'
+import { PhaseTable, TFeedUnit } from '../components/feature/PhaseTable'
 
 const Results = styled.div`
   display: flex;
@@ -29,10 +29,16 @@ const DividerWithLargeSpacings = styled(Divider)`
   margin-bottom: 55px;
 `
 
+export type TFeedFlow = { unit: TFeedUnit; value: number }
+
 export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const { mercuryApi } = props
   const [components, setComponents] = useState<ComponentResponse>()
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [feedFlow, setFeedFlow] = useState<TFeedFlow>({
+    unit: 'Sm3/d',
+    value: 1000,
+  })
   const [result, setResult] = useState<MultiflashResponse>({
     phaseValues: {},
     componentFractions: {},
@@ -62,10 +68,12 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           mercuryApi={mercuryApi}
           setResult={setResult}
           components={components}
+          feedFlow={feedFlow}
+          setFeedFlow={setFeedFlow}
         />
         <DividerWithLargeSpacings />
         <Results>
-          <PhaseTable multiFlashResponse={result} />
+          <PhaseTable multiFlashResponse={result} feedFlow={feedFlow} />
           <MoleTable multiFlashResponse={result} components={components} />
         </Results>
       </Container>


### PR DESCRIPTION
## Why is this pull request needed?

Feed flow is part of input.

## What does this pull request change?

Moved the switch from PhaseTable to a separate card below CalculateFluid.

## Issues related to this change:
Closes #95