### PR TITLE
Feature/place componentselector

### DIFF
--- a/web/src/components/feature/CalculateFluid.tsx
+++ b/web/src/components/feature/CalculateFluid.tsx
@@ -3,7 +3,11 @@ import { Card } from '../common/Card'
 import styled from 'styled-components'
 import { FluidDialog } from './FluidDialog'
 import { useState } from 'react'
-import { Multiflash, MultiflashResponse } from '../../api/generated'
+import {
+  ComponentResponse,
+  Multiflash,
+  MultiflashResponse,
+} from '../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../api/MercuryAPI'
 
@@ -28,9 +32,11 @@ const FluidPackage = styled(FlexContainer)`
 export const CalculateFluid = ({
   mercuryApi,
   setResult,
+  components,
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: MultiflashResponse) => void
+  components: ComponentResponse
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [temperature, setTemperature] = useState(15)
@@ -122,7 +128,11 @@ export const CalculateFluid = ({
           </FlexContainer>
         </Form>
       </Card>
-      <FluidDialog open={isOpen} onClose={() => setIsOpen(false)} />
+      <FluidDialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        components={components}
+      />
     </>
   )
 }

--- a/web/src/components/feature/ComponentSelector.tsx
+++ b/web/src/components/feature/ComponentSelector.tsx
@@ -37,9 +37,6 @@ export const ComponentSelector = ({
 
   return (
     <ComponentSelectorContainer>
-      <ComponentTableContainer>
-        <ComponentTable input={selectedEntries} />
-      </ComponentTableContainer>
       <Autocomplete
         onOptionsChange={({ selectedItems }) => {
           setSelectedEntries(selectedItems)
@@ -51,6 +48,9 @@ export const ComponentSelector = ({
           `${option.altName} (${option.chemicalFormula})`
         }
       />
+      <ComponentTableContainer>
+        <ComponentTable input={selectedEntries} />
+      </ComponentTableContainer>
     </ComponentSelectorContainer>
   )
 }

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -4,7 +4,10 @@ import { ComponentSelector } from './ComponentSelector'
 import { ComponentResponse } from '../../api/generated'
 
 const WideDialog = styled(Dialog)`
-  min-width: 700px;
+  width: auto;
+  @media (min-width: 900px) {
+    min-width: 800px;
+  }
 `
 
 const FluidPackageForm = styled.div`

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -1,11 +1,15 @@
 import { Button, Dialog, TextField } from '@equinor/eds-core-react'
+import { ComponentSelector } from './ComponentSelector'
+import { ComponentResponse } from '../../api/generated'
 
 export const FluidDialog = ({
   open,
   onClose,
+  components,
 }: {
   open: boolean
   onClose: () => void
+  components: ComponentResponse
 }) => {
   return (
     <Dialog open={open} onClose={onClose}>
@@ -23,6 +27,7 @@ export const FluidDialog = ({
           placeholder="Description"
           label="Description"
         />
+        <ComponentSelector components={components} />
       </Dialog.CustomContent>
       <Dialog.Actions>
         <Button color="danger" variant="outlined">

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -7,21 +7,15 @@ const WideDialog = styled(Dialog)`
   min-width: 700px;
 `
 
-const Form = styled.div`
+const FluidPackageForm = styled.div`
   display: flex;
   flex-flow: row wrap;
   gap: 30px;
 `
 
-const Left = styled.div`
+const FirstColumn = styled.div`
   display: flex;
   flex-flow: column nowrap;
-  gap: 30px;
-`
-
-const CustomDialogActions = styled(Dialog.Actions)`
-  display: flex;
-  flex-flow: row nowrap;
   gap: 30px;
 `
 
@@ -40,8 +34,8 @@ export const FluidDialog = ({
         <Dialog.Title>Create fluid package</Dialog.Title>
       </Dialog.Header>
       <Dialog.CustomContent>
-        <Form>
-          <Left>
+        <FluidPackageForm>
+          <FirstColumn>
             <TextField
               id="fluid-package-name"
               placeholder="Fluid package"
@@ -51,12 +45,13 @@ export const FluidDialog = ({
               id="fluid-package-description"
               placeholder="Description"
               label="Description"
+              multiline
             />
-          </Left>
+          </FirstColumn>
           <ComponentSelector components={components} />
-        </Form>
+        </FluidPackageForm>
       </Dialog.CustomContent>
-      <CustomDialogActions>
+      <Dialog.Actions>
         <Button color="danger" variant="outlined">
           Delete
         </Button>
@@ -64,7 +59,7 @@ export const FluidDialog = ({
           Cancel
         </Button>
         <Button type="submit">Save</Button>
-      </CustomDialogActions>
+      </Dialog.Actions>
     </WideDialog>
   )
 }

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -1,6 +1,29 @@
+import styled from 'styled-components'
 import { Button, Dialog, TextField } from '@equinor/eds-core-react'
 import { ComponentSelector } from './ComponentSelector'
 import { ComponentResponse } from '../../api/generated'
+
+const WideDialog = styled(Dialog)`
+  min-width: 700px;
+`
+
+const Form = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  gap: 30px;
+`
+
+const Left = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 30px;
+`
+
+const CustomDialogActions = styled(Dialog.Actions)`
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 30px;
+`
 
 export const FluidDialog = ({
   open,
@@ -12,24 +35,28 @@ export const FluidDialog = ({
   components: ComponentResponse
 }) => {
   return (
-    <Dialog open={open} onClose={onClose}>
+    <WideDialog open={open} onClose={onClose}>
       <Dialog.Header>
-        <Dialog.Title>Fluid package</Dialog.Title>
+        <Dialog.Title>Create fluid package</Dialog.Title>
       </Dialog.Header>
       <Dialog.CustomContent>
-        <TextField
-          id="fluid-package-name"
-          placeholder="Fluid package"
-          label="Name"
-        />
-        <TextField
-          id="fluid-package-description"
-          placeholder="Description"
-          label="Description"
-        />
-        <ComponentSelector components={components} />
+        <Form>
+          <Left>
+            <TextField
+              id="fluid-package-name"
+              placeholder="Fluid package"
+              label="Name"
+            />
+            <TextField
+              id="fluid-package-description"
+              placeholder="Description"
+              label="Description"
+            />
+          </Left>
+          <ComponentSelector components={components} />
+        </Form>
       </Dialog.CustomContent>
-      <Dialog.Actions>
+      <CustomDialogActions>
         <Button color="danger" variant="outlined">
           Delete
         </Button>
@@ -37,7 +64,7 @@ export const FluidDialog = ({
           Cancel
         </Button>
         <Button type="submit">Save</Button>
-      </Dialog.Actions>
-    </Dialog>
+      </CustomDialogActions>
+    </WideDialog>
   )
 }

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -7,7 +7,6 @@ import { CalculateFluid } from '../components/feature/CalculateFluid'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
-import { ComponentSelector } from '../components/feature/ComponentSelector'
 import { PhaseTable } from '../components/feature/PhaseTable'
 
 const Results = styled.div`
@@ -59,8 +58,11 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
     <>
       <Header />
       <Container>
-        <CalculateFluid mercuryApi={mercuryApi} setResult={setResult} />
-        <ComponentSelector components={components} />
+        <CalculateFluid
+          mercuryApi={mercuryApi}
+          setResult={setResult}
+          components={components}
+        />
         <DividerWithLargeSpacings />
         <Results>
           <PhaseTable multiFlashResponse={result} />


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because the ComponentSelector should be inside the Dialog

## What does this pull request change?

* Moves ComponentSelector into the dialog
* Adjust dialog width and styling to fit the new content
* Change order of autocomplete and table inside ComponentSelector

## Issues related to this change:

Closes #84