### PR TITLE
ci: disable eslint for building

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,6 @@ on:
 
 env:
   RADIX_APP: mercury
-  # TODO ?
   RADIX_USER: mlw@equinor.com
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,9 +84,9 @@ repos:
           - eslint-plugin-prettier # runs prettier as an eslint rule
           - eslint-plugin-react # react specific linting rules
           - eslint-plugin-react-hooks # enforces the rules of hooks
-        files: ^web/src/.*\.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
+        files: ^web\/src\/(?!.*generated).*\.(tsx|js|jsx|ts)$  # *.js, *.jsx, *.ts and *.tsx (excluding 'generated')
         types: [file]
-        args: ["--config=web/.eslintrc.json", "--ignore-path=web/.eslintignore"]
+        args: [--config=web/.eslintrc.json, --fix]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1

--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -1,5 +1,3 @@
-**/gen/*
 web/src/api/generated
-
 build
 coverage

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -31,6 +31,7 @@
     "prettier"
   ],
   "rules": {
+    "@typescript-eslint/no-unused-vars": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "react/boolean-prop-naming": "warn",

--- a/web/package.json
+++ b/web/package.json
@@ -38,8 +38,8 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "test-ci": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Disables eslint for running and building the web app. Also fixes eslint pre-commit hook to not show warning on ignored files, and to actually fix the code when run.

The reasoning is that a linting tool should not stop the app from building. The linting will still be checked in the tests.

Note: Open for debate on this one...
