### PR TITLE
refactor: Create types file

### DIFF
--- a/web/src/components/feature/CalculateFluid.tsx
+++ b/web/src/components/feature/CalculateFluid.tsx
@@ -12,7 +12,7 @@ import { ComponentResponse, MultiflashResponse } from '../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../api/MercuryAPI'
 import { FeedFlowInput } from './FeedFlowInput'
-import { TComponentComposition, TFeedFlow } from '../../pages/Main'
+import { TComponentComposition, TFeedFlow } from '../../types'
 
 const FlexContainer = styled.div`
   display: flex;

--- a/web/src/components/feature/ComponentSelector.tsx
+++ b/web/src/components/feature/ComponentSelector.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import { ComponentTable } from './ComponentTable'
 import { preSelectedComponents } from '../../constants'
-import { TComponent, TComponentInput } from './FluidDialog'
+import { TComponent, TComponentInput } from '../../types'
 
 const ComponentSelectorContainer = styled.div`
   display: flex;

--- a/web/src/components/feature/ComponentTable.tsx
+++ b/web/src/components/feature/ComponentTable.tsx
@@ -1,5 +1,5 @@
 import { EdsProvider, Table, TextField } from '@equinor/eds-core-react'
-import { TComponent, TComponentInput } from './FluidDialog'
+import { TComponent, TComponentInput } from '../../types'
 
 export const ComponentTable = ({
   input,

--- a/web/src/components/feature/FeedFlowInput.tsx
+++ b/web/src/components/feature/FeedFlowInput.tsx
@@ -1,7 +1,6 @@
 import { Switch, TextField } from '@equinor/eds-core-react'
 import styled from 'styled-components'
-import { Card } from '../common/Card'
-import { TFeedFlow } from '../../pages/Main'
+import { TFeedFlow } from '../../types'
 
 const FlexContainer = styled.div`
   display: flex;

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components'
 import { Button, Dialog, TextField } from '@equinor/eds-core-react'
 import { ComponentSelector } from './ComponentSelector'
 import { ComponentResponse } from '../../api/generated'
-import { TComponentComposition } from '../../pages/Main'
 import { useState } from 'react'
 import { demoComponentInput, demoFeedComponentRatios } from '../../constants'
+import { TComponentInput, TComponentComposition } from '../../types'
 
 const WideDialog = styled(Dialog)`
   width: auto;
@@ -24,21 +24,6 @@ const FirstColumn = styled.div`
   flex-flow: column nowrap;
   gap: 30px;
 `
-
-export type TComponent = {
-  componentId: string
-  altName: string
-  chemicalFormula: string
-  value: number
-}
-
-export type TComponentInput = {
-  [componentId: string]: {
-    altName: string
-    chemicalFormula: string
-    value: number
-  }
-}
 
 function convertComponentResponseToComponentInput(
   components: ComponentResponse

--- a/web/src/components/feature/PhaseTable.tsx
+++ b/web/src/components/feature/PhaseTable.tsx
@@ -1,9 +1,7 @@
 import { DynamicTable } from '../common/DynamicTable'
 import { MultiflashResponse } from '../../api/generated'
-import { TFeedFlow } from '../../pages/Main'
+import { TFeedFlow } from '../../types'
 import { formatNumber } from '../../tableUtils'
-
-export type TFeedUnit = 'kg/d' | 'Sm3/d'
 
 function getRows(
   multiFlashResponse: MultiflashResponse,

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -7,8 +7,9 @@ import { CalculateFluid } from '../components/feature/CalculateFluid'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
-import { PhaseTable, TFeedUnit } from '../components/feature/PhaseTable'
+import { PhaseTable } from '../components/feature/PhaseTable'
 import { MercuryWarning } from '../components/feature/MercuryWarning'
+import { TComponentComposition, TFeedFlow } from '../types'
 
 const Results = styled.div`
   display: flex;
@@ -29,9 +30,6 @@ const Container = styled.div`
 const DividerWithLargeSpacings = styled(Divider)`
   margin-top: 40px;
 `
-
-export type TFeedFlow = { unit: TFeedUnit; value: number }
-export type TComponentComposition = { [componentId: string]: number }
 
 export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const { mercuryApi } = props

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,17 @@
+export type TComponent = {
+  componentId: string
+  altName: string
+  chemicalFormula: string
+  value: number
+}
+
+export type TComponentInput = {
+  [componentId: string]: {
+    altName: string
+    chemicalFormula: string
+    value: number
+  }
+}
+export type TComponentComposition = { [componentId: string]: number }
+export type TFeedUnit = 'kg/d' | 'Sm3/d'
+export type TFeedFlow = { unit: TFeedUnit; value: number }


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because gathering all exported types in one file makes it easier to get an overview of our types

## What does this pull request change?

Moves all exported types into a types file

## Issues related to this change: