### PR TITLE
feature: load saved package when selected

### DIFF
--- a/web/src/components/common/Header.tsx
+++ b/web/src/components/common/Header.tsx
@@ -72,6 +72,13 @@ export const Header = (): JSX.Element => {
           >
             Logout
           </Button>
+          <Button
+            onClick={() => localStorage.removeItem('packages')}
+            color={'secondary'}
+            variant={'outlined'}
+          >
+            Reset application
+          </Button>
         </Popover.Actions>
       </Popover>
       <Popover open={isAboutOpen} anchorEl={infoRefElement.current}>

--- a/web/src/components/feature/CalculationInput.tsx
+++ b/web/src/components/feature/CalculationInput.tsx
@@ -1,5 +1,6 @@
 import {
   Autocomplete,
+  AutocompleteChanges,
   Button,
   Progress,
   TextField,
@@ -33,7 +34,7 @@ const FluidPackage = styled(FlexContainer)`
   }
 `
 
-export const CalculateFluid = ({
+export const CalculationInput = ({
   mercuryApi,
   setResult,
   components,
@@ -54,7 +55,10 @@ export const CalculateFluid = ({
   const [temperature, setTemperature] = useState<number>(15)
   const [pressure, setPressure] = useState<number>(1)
   const [calculating, setCalculating] = useState<boolean>(false)
-  const [packages, setPackages] = useLocalStorage<TPackage[]>('packages', [])
+  const [packages, setPackages] = useLocalStorage<{ [name: string]: TPackage }>(
+    'packages',
+    {}
+  )
 
   const calculate = (
     <Button
@@ -91,6 +95,15 @@ export const CalculateFluid = ({
     </Button>
   )
 
+  function setLoadedFluidPackage(selectedPackages: string[]): void {
+    // There will always be ether 0 or 1 selected package
+    if (!selectedPackages.length) return
+    const allPackages: { [name: string]: TPackage } = JSON.parse(
+      localStorage.getItem('packages') ?? '{}'
+    )
+    setComponentComposition(allPackages[selectedPackages[0]].components)
+  }
+
   return (
     <>
       <Card title={'Calculate Fluid'} actions={calculate}>
@@ -98,8 +111,11 @@ export const CalculateFluid = ({
           <FluidPackage>
             <Autocomplete
               label="Fluid package"
-              options={packages.map((x) => x.name)}
+              options={Object.keys(packages).map((x) => x)}
               autoWidth
+              onOptionsChange={(value: AutocompleteChanges<string>) =>
+                setLoadedFluidPackage(value.selectedItems)
+              }
             />
             <Button variant="outlined" onClick={() => setIsOpen(true)}>
               New

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -69,8 +69,8 @@ export const FluidDialog = ({
   close: () => void
   components: ComponentResponse
   setComponentComposition: (feedComponentRatios: TComponentComposition) => void
-  packages: TPackage[]
-  setPackages: (v: TPackage[]) => void
+  packages: { [name: string]: TPackage }
+  setPackages: (v: { [name: string]: TPackage }) => void
 }) => {
   // Array of components containing input from user
   const [componentInput, setComponentInput] = useState<TComponentInput>(
@@ -99,14 +99,14 @@ export const FluidDialog = ({
   const savePackage = () => {
     const componentComposition = getComponentComposition()
     setComponentComposition(normalizeComponentComposition(componentComposition))
-    setPackages([
+    setPackages({
       ...packages,
-      {
+      [packageName]: {
         name: packageName,
         description: packageDescription,
         components: componentComposition,
       },
-    ])
+    })
     close()
   }
 

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -3,7 +3,7 @@ import { Divider, Typography } from '@equinor/eds-core-react'
 import { Header } from '../components/common/Header'
 import { useEffect, useState } from 'react'
 import { MoleTable } from '../components/feature/MoleTable'
-import { CalculateFluid } from '../components/feature/CalculateFluid'
+import { CalculationInput } from '../components/feature/CalculationInput'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
@@ -63,7 +63,7 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
     <>
       <Header />
       <Container>
-        <CalculateFluid
+        <CalculationInput
           mercuryApi={mercuryApi}
           setResult={setResult}
           components={components}


### PR DESCRIPTION
## Why is this pull request needed?

Should be able to reuse saved packages

## What does this pull request change?
- Rename "CalculateFluid" component to "Input"
- Refactor stored packages to be a dict instead of a list with packages
- Load the package selected in the dropdown

## Issues related to this change:
none, but needed for #120 