### PR TITLE
fix: only preSelected components was selectable

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
+    "start": "ESLINT_NO_DEV_ERRORS='true' WDS_SOCKET_PORT=80 react-scripts start",
     "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "test-ci": "react-scripts test --watchAll=false",

--- a/web/src/components/feature/CalculateFluid.tsx
+++ b/web/src/components/feature/CalculateFluid.tsx
@@ -47,7 +47,7 @@ export const CalculateFluid = ({
   components: ComponentResponse
   feedFlow: TFeedFlow
   setFeedFlow: (feedFlow: TFeedFlow) => void
-  componentComposition: TComponentComposition
+  componentComposition: TComponentComposition | undefined
   setComponentComposition: (feedComponentRatios: TComponentComposition) => void
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
@@ -59,8 +59,9 @@ export const CalculateFluid = ({
   const calculate = (
     <Button
       data-testid="computeMf"
-      disabled={calculating}
+      disabled={calculating || !componentComposition}
       onClick={() => {
+        if (!componentComposition) return
         setCalculating(true)
         mercuryApi
           .computeMultiflash({
@@ -86,13 +87,7 @@ export const CalculateFluid = ({
           })
       }}
     >
-      {calculating && (
-        <>
-          <Progress.Circular size={16} color="neutral" />
-          Calculating...
-        </>
-      )}
-      {!calculating && <>Run</>}
+      {calculating ? <Progress.Circular size={16} color="neutral" /> : <>Run</>}
     </Button>
   )
 
@@ -137,8 +132,8 @@ export const CalculateFluid = ({
         </Form>
       </Card>
       <FluidDialog
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
+        isOpen={isOpen}
+        close={() => setIsOpen(false)}
         components={components}
         setComponentComposition={setComponentComposition}
         packages={packages}

--- a/web/src/components/feature/ComponentSelector.tsx
+++ b/web/src/components/feature/ComponentSelector.tsx
@@ -12,13 +12,6 @@ const ComponentSelectorContainer = styled.div`
   max-width: 500px;
 `
 
-const ComponentTableContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 420px;
-  overflow: auto;
-`
-
 function createOptions(componentInput: TComponentInput): TComponent[] {
   // Convert TComponentInput to TComponent for table
   return Object.entries(componentInput).map(([componentId, entry]) => ({
@@ -62,13 +55,11 @@ export const ComponentSelector = ({
           `${option.altName} (${option.chemicalFormula})`
         }
       />
-      <ComponentTableContainer>
-        <ComponentTable
-          input={selectedComponents}
-          componentInput={componentInput}
-          setComponentInput={setComponentInput}
-        />
-      </ComponentTableContainer>
+      <ComponentTable
+        input={selectedComponents}
+        componentInput={componentInput}
+        setComponentInput={setComponentInput}
+      />
     </ComponentSelectorContainer>
   )
 }

--- a/web/src/components/feature/ComponentTable.tsx
+++ b/web/src/components/feature/ComponentTable.tsx
@@ -1,5 +1,14 @@
 import { EdsProvider, Table, TextField } from '@equinor/eds-core-react'
 import { TComponent, TComponentInput } from '../../types'
+import styled from 'styled-components'
+
+const ComponentTableContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 550px;
+  overflow: auto;
+  margin-top: 15px;
+`
 
 export const ComponentTable = ({
   input,
@@ -35,18 +44,20 @@ export const ComponentTable = ({
   }
 
   return (
-    <EdsProvider density={'compact'}>
-      <Table>
-        <Table.Head>
-          <Table.Row>
-            <Table.Cell key={`Component`}>{`Component`}</Table.Cell>
-            <Table.Cell
-              key={`Feed value (mol)`}
-            >{`Feed value (mol)`}</Table.Cell>
-          </Table.Row>
-        </Table.Head>
-        <Table.Body>{createTableRows()}</Table.Body>
-      </Table>
-    </EdsProvider>
+    <ComponentTableContainer>
+      <EdsProvider density={'compact'}>
+        <Table>
+          <Table.Head sticky>
+            <Table.Row>
+              <Table.Cell key={`Component`}>{`Component`}</Table.Cell>
+              <Table.Cell
+                key={`Feed value (mol)`}
+              >{`Feed value (mol)`}</Table.Cell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>{createTableRows()}</Table.Body>
+        </Table>
+      </EdsProvider>
+    </ComponentTableContainer>
   )
 }

--- a/web/src/components/feature/FeedFlowInput.tsx
+++ b/web/src/components/feature/FeedFlowInput.tsx
@@ -5,6 +5,7 @@ import { TFeedFlow } from '../../types'
 const FlexContainer = styled.div`
   display: flex;
   gap: 16px;
+  max-width: 250px;
 `
 
 export const FeedFlowInput = (props: {
@@ -26,7 +27,7 @@ export const FeedFlowInput = (props: {
         }
       />
       <Switch
-        label="Unit"
+        label="unit"
         checked={props.feedFlow.unit === 'kg/d'}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           props.setFeedFlow({

--- a/web/src/components/feature/FluidDialog.tsx
+++ b/web/src/components/feature/FluidDialog.tsx
@@ -58,24 +58,24 @@ function normalizeComponentComposition(
 }
 
 export const FluidDialog = ({
-  open,
-  onClose,
+  isOpen,
+  close,
   components,
   setComponentComposition,
   packages,
   setPackages,
 }: {
-  open: boolean
-  onClose: () => void
+  isOpen: boolean
+  close: () => void
   components: ComponentResponse
   setComponentComposition: (feedComponentRatios: TComponentComposition) => void
   packages: TPackage[]
   setPackages: (v: TPackage[]) => void
 }) => {
   // Array of components containing input from user
-  const [componentInput, setComponentInput] = useState<TComponentInput>(() => {
-    return convertComponentResponseToComponentInput(components)
-  })
+  const [componentInput, setComponentInput] = useState<TComponentInput>(
+    convertComponentResponseToComponentInput(components)
+  )
   const [packageName, setPackageName] = useState<string>('')
   const [packageDescription, setPackageDescription] = useState<string>('')
 
@@ -93,7 +93,7 @@ export const FluidDialog = ({
     setComponentComposition(
       normalizeComponentComposition(getComponentComposition())
     )
-    onClose()
+    close()
   }
 
   const savePackage = () => {
@@ -107,11 +107,11 @@ export const FluidDialog = ({
         components: componentComposition,
       },
     ])
-    onClose()
+    close()
   }
 
   return (
-    <WideDialog open={open} onClose={onClose}>
+    <WideDialog open={isOpen} onClose={close} isDismissable={true}>
       <Dialog.Header>
         <Dialog.Title>Create fluid package</Dialog.Title>
       </Dialog.Header>
@@ -148,17 +148,19 @@ export const FluidDialog = ({
         <Button color="danger" variant="outlined">
           Delete
         </Button>
-        <Button variant="outlined" onClick={onClose}>
+        <Button variant="outlined" onClick={close}>
           Cancel
         </Button>
         <Button onClick={applyPackage}>Apply</Button>
-        <Button onClick={savePackage}>Save</Button>
+        <Button onClick={savePackage} disabled={!packageName}>
+          Save
+        </Button>
         <Button
           // TODO: Demo button to remove when done testing
           onClick={() => {
             setComponentComposition(demoFeedComponentRatios)
             setComponentInput(demoComponentInput)
-            onClose()
+            close()
           }}
         >
           Demo data

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Divider } from '@equinor/eds-core-react'
+import { Divider, Typography } from '@equinor/eds-core-react'
 import { Header } from '../components/common/Header'
 import { useEffect, useState } from 'react'
 import { MoleTable } from '../components/feature/MoleTable'
@@ -18,6 +18,7 @@ const Results = styled.div`
   align-items: center;
   flex-wrap: wrap;
   margin-top: 40px;
+  align-items: flex-start;
 `
 
 const Container = styled.div`
@@ -40,12 +41,8 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
     value: 1000,
   })
   const [componentComposition, setComponentComposition] =
-    useState<TComponentComposition>({})
-  const [result, setResult] = useState<MultiflashResponse>({
-    phaseValues: {},
-    componentFractions: {},
-    feedMolecularWeight: 0,
-  })
+    useState<TComponentComposition>()
+  const [result, setResult] = useState<MultiflashResponse>()
 
   // Fetch list of components name once on page load
   useEffect(() => {
@@ -76,15 +73,24 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           setComponentComposition={setComponentComposition}
         />
         <DividerWithLargeSpacings />
-        {'Mercury' in result.phaseValues && <MercuryWarning />}
-        <Results>
-          <PhaseTable multiFlashResponse={result} feedFlow={feedFlow} />
-          <MoleTable
-            multiFlashResponse={result}
-            components={components}
-            componentComposition={componentComposition}
-          />
-        </Results>
+        {!result && (
+          <Typography variant="body_short" color="primary">
+            Run a calculation to get results
+          </Typography>
+        )}
+        {result && componentComposition && (
+          <>
+            {'Mercury' in result.phaseValues && <MercuryWarning />}
+            <Results>
+              <PhaseTable multiFlashResponse={result} feedFlow={feedFlow} />
+              <MoleTable
+                multiFlashResponse={result}
+                components={components}
+                componentComposition={componentComposition}
+              />
+            </Results>
+          </>
+        )}
       </Container>
     </>
   )


### PR DESCRIPTION
## Why is this pull request needed?

Fixes a bug where only the 12 preSelected somponents where selectable in the ComponentSelector.

## What does this pull request change?

Also some refactor/minor changes:

 - react hot reload now works on port 80 (WDS_SOCKET_PORT env var)
 - disable run button when no components are selected
 - disable save button when no packageName is set
 - rename FluidDialog 'open' and 'onClose' to 'isOpen' and 'close'
 - render some helpful text where the results will come


## Issues related to this change:

none, and resoles #118 