### PR TITLE
feat: add conversion between feed units

### DIFF
--- a/web/src/components/feature/CalculationInput.tsx
+++ b/web/src/components/feature/CalculationInput.tsx
@@ -13,7 +13,7 @@ import { ComponentResponse, MultiflashResponse } from '../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../api/MercuryAPI'
 import { FeedFlowInput } from './FeedFlowInput'
-import { TComponentComposition, TFeedFlow, TPackage } from '../../types'
+import { TComponentComposition, TPackage } from '../../types'
 import useLocalStorage from '../../hooks/useLocalStorage'
 
 const FlexContainer = styled.div`
@@ -38,16 +38,16 @@ export const CalculationInput = ({
   mercuryApi,
   setResult,
   components,
-  feedFlow,
-  setFeedFlow,
+  cubicFeedFlow,
+  setCubicFeedFlow,
   componentComposition,
   setComponentComposition,
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: MultiflashResponse) => void
   components: ComponentResponse
-  feedFlow: TFeedFlow
-  setFeedFlow: (feedFlow: TFeedFlow) => void
+  cubicFeedFlow: number
+  setCubicFeedFlow: (cubicFeedFlow: number) => void
   componentComposition: TComponentComposition | undefined
   setComponentComposition: (feedComponentRatios: TComponentComposition) => void
 }) => {
@@ -55,6 +55,7 @@ export const CalculationInput = ({
   const [temperature, setTemperature] = useState<number>(15)
   const [pressure, setPressure] = useState<number>(1)
   const [calculating, setCalculating] = useState<boolean>(false)
+  const [feedMolecularWeight, setFeedMolecularWeight] = useState<number>()
   const [packages, setPackages] = useLocalStorage<{ [name: string]: TPackage }>(
     'packages',
     {}
@@ -144,7 +145,11 @@ export const CalculationInput = ({
               }
             />
           </FlexContainer>
-          <FeedFlowInput feedFlow={feedFlow} setFeedFlow={setFeedFlow} />
+          <FeedFlowInput
+            cubicFeedFlow={cubicFeedFlow}
+            setCubicFeedFlow={setCubicFeedFlow}
+            feedMolecularWeight={feedMolecularWeight}
+          />
         </Form>
       </Card>
       <FluidDialog
@@ -152,6 +157,7 @@ export const CalculationInput = ({
         close={() => setIsOpen(false)}
         components={components}
         setComponentComposition={setComponentComposition}
+        setFeedMolecularWeight={setFeedMolecularWeight}
         packages={packages}
         setPackages={setPackages}
       />

--- a/web/src/components/feature/ComponentTable.tsx
+++ b/web/src/components/feature/ComponentTable.tsx
@@ -28,11 +28,11 @@ export const ComponentTable = ({
         <Table.Cell data-testid={`Ratio (mol)-${index}`}>
           <TextField
             id={`${entry.chemicalFormula}-input`}
-            defaultValue={componentInput[entry.componentId].value}
+            defaultValue={componentInput[entry.componentId].feedValue}
             min={0}
             type="number"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              componentInput[entry.componentId].value = Number(
+              componentInput[entry.componentId].feedValue = Number(
                 event.target.value
               )
               setComponentInput(componentInput)

--- a/web/src/components/feature/PhaseTable.test.tsx
+++ b/web/src/components/feature/PhaseTable.test.tsx
@@ -7,7 +7,7 @@ test('renders without crashing and displaying correct values in table', async ()
   render(
     <PhaseTable
       multiFlashResponse={mockMultiflashResponse}
-      feedFlow={{ unit: 'Sm3/d', value: 0 }}
+      cubicFeedFlow={1000}
     />
   )
   // @ts-ignore because not able to get eslint to discover these types

--- a/web/src/components/feature/PhaseTable.tsx
+++ b/web/src/components/feature/PhaseTable.tsx
@@ -1,14 +1,17 @@
 import { DynamicTable } from '../common/DynamicTable'
 import { MultiflashResponse } from '../../api/generated'
-import { TFeedFlow } from '../../types'
 import { formatNumber } from '../../tableUtils'
+import {
+  mercuryMolecularWeight,
+  molePerStandardCubicMeter,
+} from '../../constants'
 
 function getRows(
   multiFlashResponse: MultiflashResponse,
-  feedFlow: number
+  cubicFeedFlow: number
 ): string[][] {
-  // TODO: Assumes feed flow unit is Sm3/d
-  const phPhaseFlowFactor = feedFlow * 42.29256 * 200.59
+  const phPhaseFlowFactor =
+    cubicFeedFlow * molePerStandardCubicMeter * mercuryMolecularWeight
   const mercury = multiFlashResponse.componentFractions['5']
   return Object.entries(multiFlashResponse.phaseValues).map(
     ([phase, values], index) => [
@@ -23,7 +26,7 @@ function getRows(
 
 export const PhaseTable = (props: {
   multiFlashResponse: MultiflashResponse
-  feedFlow: TFeedFlow
+  cubicFeedFlow: number
 }) => {
   return (
     <DynamicTable
@@ -34,7 +37,7 @@ export const PhaseTable = (props: {
         'Mole Concentration',
         'Mercury Flow (g/d)',
       ]}
-      rows={getRows(props.multiFlashResponse, props.feedFlow.value)}
+      rows={getRows(props.multiFlashResponse, props.cubicFeedFlow)}
       density={'comfortable'}
     />
   )

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -9,6 +9,12 @@ export const authConfig = {
   logoutEndpoint: process.env.REACT_APP_LOGOUT_ENDPOINT || '',
 }
 
+// Molecular weight of mercury
+export const mercuryMolecularWeight = 200.59
+
+// Approximate mole in 1 Sm3 (from ideal gas law with K = 288.15, P=1.01325)
+export const molePerStandardCubicMeter = 42.29256
+
 export const preSelectedComponents: Array<string> = [
   '5',
   '1',
@@ -43,61 +49,73 @@ export const demoComponentInput = {
   '3': {
     altName: 'Water',
     chemicalFormula: 'H2O',
-    value: 0.062202,
+    molecularWeight: 18.015,
+    feedValue: 0.062202,
   },
   '2': {
     altName: 'Nitrogen',
     chemicalFormula: 'N2',
-    value: 0.0047,
+    molecularWeight: 28.014,
+    feedValue: 0.0047,
   },
   '1': {
     altName: 'Carbondioxide',
     chemicalFormula: 'CO2',
-    value: 0.046539,
+    molecularWeight: 44.01,
+    feedValue: 0.046539,
   },
   '101': {
     altName: 'Methane',
     chemicalFormula: 'CH4',
-    value: 0.65364,
+    molecularWeight: 16.043,
+    feedValue: 0.65364,
   },
   '201': {
     altName: 'Ethane',
     chemicalFormula: 'C2H6',
-    value: 0.086307,
+    molecularWeight: 30.07,
+    feedValue: 0.086307,
   },
   '301': {
     altName: 'Propane',
     chemicalFormula: 'nC3',
-    value: 0.045563,
+    molecularWeight: 44.096,
+    feedValue: 0.045563,
   },
   '401': {
     altName: 'i-Butane',
     chemicalFormula: 'iC4',
-    value: 0.007579,
+    molecularWeight: 58.123,
+    feedValue: 0.007579,
   },
   '402': {
     altName: 'n-Butane',
     chemicalFormula: 'nC4',
-    value: 0.015481,
+    molecularWeight: 58.123,
+    feedValue: 0.015481,
   },
   '503': {
     altName: 'i-Pentane',
     chemicalFormula: 'iC5',
-    value: 0.005188,
+    molecularWeight: 72.15,
+    feedValue: 0.005188,
   },
   '504': {
     altName: 'n-Pentane',
     chemicalFormula: 'nC5',
-    value: 0.00612,
+    molecularWeight: 72.15,
+    feedValue: 0.00612,
   },
   '605': {
     altName: 'n-Hexane',
     chemicalFormula: 'nC6',
-    value: 0.066681,
+    molecularWeight: 86.177,
+    feedValue: 0.066681,
   },
   '5': {
     altName: 'Mercury',
     chemicalFormula: 'Hg',
-    value: 0.001,
+    molecularWeight: 200.59,
+    feedValue: 0.001,
   },
 }

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -9,7 +9,7 @@ import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
 import { PhaseTable } from '../components/feature/PhaseTable'
 import { MercuryWarning } from '../components/feature/MercuryWarning'
-import { TComponentComposition, TFeedFlow } from '../types'
+import { TComponentComposition } from '../types'
 
 const Results = styled.div`
   display: flex;
@@ -36,10 +36,9 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const { mercuryApi } = props
   const [components, setComponents] = useState<ComponentResponse>()
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [feedFlow, setFeedFlow] = useState<TFeedFlow>({
-    unit: 'Sm3/d',
-    value: 1000,
-  })
+
+  // feedFlow unit is Sm3/d
+  const [cubicFeedFlow, setCubicFeedFlow] = useState<number>(1000)
   const [componentComposition, setComponentComposition] =
     useState<TComponentComposition>()
   const [result, setResult] = useState<MultiflashResponse>()
@@ -67,8 +66,8 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           mercuryApi={mercuryApi}
           setResult={setResult}
           components={components}
-          feedFlow={feedFlow}
-          setFeedFlow={setFeedFlow}
+          cubicFeedFlow={cubicFeedFlow}
+          setCubicFeedFlow={setCubicFeedFlow}
           componentComposition={componentComposition}
           setComponentComposition={setComponentComposition}
         />
@@ -82,7 +81,10 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           <>
             {'Mercury' in result.phaseValues && <MercuryWarning />}
             <Results>
-              <PhaseTable multiFlashResponse={result} feedFlow={feedFlow} />
+              <PhaseTable
+                multiFlashResponse={result}
+                cubicFeedFlow={cubicFeedFlow}
+              />
               <MoleTable
                 multiFlashResponse={result}
                 components={components}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,19 +2,19 @@ export type TComponent = {
   componentId: string
   altName: string
   chemicalFormula: string
-  value: number
+  feedValue: number
 }
 
 export type TComponentInput = {
   [componentId: string]: {
     altName: string
     chemicalFormula: string
-    value: number
+    molecularWeight: number
+    feedValue: number
   }
 }
 export type TComponentComposition = { [componentId: string]: number }
 export type TFeedUnit = 'kg/d' | 'Sm3/d'
-export type TFeedFlow = { unit: TFeedUnit; value: number }
 export type TPackage = {
   name: string
   description: string


### PR DESCRIPTION
## Why is this pull request needed?
Add support for conversion of feed units.

## What does this pull request change?
User can now convert between units and the conversion will happen in the UI. Unit switch is disabled until a composition feed is selected.

## Issues related to this change:
Closes #80