### PR TITLE
feat: add conversion of feed flow between units

### DIFF
--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -15,7 +15,6 @@ import { FeedFlowInput } from './FeedFlowInput'
 import {
   TComponentProperties,
   TComponentRatios,
-  TFeedFlow,
   TPackage,
 } from '../../../types'
 import useLocalStorage from '../../../hooks/useLocalStorage'
@@ -42,15 +41,15 @@ export const CalculationInput = ({
   mercuryApi,
   setResult,
   componentProperties,
-  feedFlow,
-  setFeedFlow,
+  cubicFeedFlow,
+  setCubicFeedFlow,
   setUsedComponentRatios,
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: MultiflashResponse) => void
   componentProperties: TComponentProperties
-  feedFlow: TFeedFlow
-  setFeedFlow: (feedFlow: TFeedFlow) => void
+  cubicFeedFlow: number
+  setCubicFeedFlow: (cubicFeedFlow: number) => void
   setUsedComponentRatios: (ratios: TComponentRatios) => void
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
@@ -137,7 +136,11 @@ export const CalculationInput = ({
               }
             />
           </FlexContainer>
-          <FeedFlowInput feedFlow={feedFlow} setFeedFlow={setFeedFlow} />
+          <FeedFlowInput
+            cubicFeedFlow={cubicFeedFlow}
+            setCubicFeedFlow={setCubicFeedFlow}
+            molecularWeightSum={selectedPackage?.molecularWeightSum}
+          />
         </Form>
       </Card>
       <FluidDialog

--- a/web/src/components/feature/calculation_input/FeedFlowInput.tsx
+++ b/web/src/components/feature/calculation_input/FeedFlowInput.tsx
@@ -1,6 +1,7 @@
 import { Switch, TextField } from '@equinor/eds-core-react'
 import styled from 'styled-components'
-import { TFeedFlow } from '../../../types'
+import { molePerStandardCubicMeter } from '../../../constants'
+import { useState } from 'react'
 
 const FlexContainer = styled.div`
   display: flex;
@@ -8,33 +9,62 @@ const FlexContainer = styled.div`
   max-width: 250px;
 `
 
+function convertFlowFromCubicToMass(
+  cubicFeedFlow: number,
+  molecularWeightSum: number
+): number {
+  return (cubicFeedFlow * molecularWeightSum * molePerStandardCubicMeter) / 1000
+}
+
+function convertFlowFromMassToCubic(
+  massFeedFlow: number,
+  molecularWeightSum: number
+): number {
+  return (
+    (massFeedFlow * 1000) / (molecularWeightSum * molePerStandardCubicMeter)
+  )
+}
+
 export const FeedFlowInput = (props: {
-  feedFlow: TFeedFlow
-  setFeedFlow: (value: TFeedFlow) => void
+  cubicFeedFlow: number
+  setCubicFeedFlow: (value: number) => void
+  molecularWeightSum: number | undefined
 }) => {
+  const [displayMassFeedFlow, setDisplayMassFeedFlow] = useState<boolean>(false)
+  const selectedUnit = displayMassFeedFlow ? 'kg/d' : 'Sm3/d'
+
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (displayMassFeedFlow)
+      props.setCubicFeedFlow(
+        convertFlowFromMassToCubic(
+          Number(event.target.value),
+          props.molecularWeightSum ?? 1
+        )
+      )
+    else props.setCubicFeedFlow(Number(event.target.value))
+  }
+
+  const displayValue = displayMassFeedFlow
+    ? convertFlowFromCubicToMass(
+        props.cubicFeedFlow,
+        props.molecularWeightSum ?? 1
+      )
+    : props.cubicFeedFlow
+
   return (
     <FlexContainer>
       <TextField
         id="feed-flow-input"
-        value={props.feedFlow.value.toString()}
-        unit={props.feedFlow.unit}
+        unit={selectedUnit}
         type="number"
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          props.setFeedFlow({
-            unit: props.feedFlow.unit,
-            value: Number(event.target.value),
-          })
-        }
+        value={(+displayValue.toFixed(2)).toString()}
+        onChange={handleChangeInput}
       />
       <Switch
         label="unit"
-        checked={props.feedFlow.unit === 'kg/d'}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          props.setFeedFlow({
-            unit: event.target.checked ? 'kg/d' : 'Sm3/d',
-            value: props.feedFlow.value,
-          })
-        }
+        checked={displayMassFeedFlow}
+        disabled={!props.molecularWeightSum}
+        onChange={(event) => setDisplayMassFeedFlow(event.target.checked)}
       />
     </FlexContainer>
   )

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -43,6 +43,17 @@ function normalizeRatios(componentRatios: TComponentRatios): TComponentRatios {
   )
 }
 
+function computeFeedMolecularWeight(
+  componentProperties: TComponentProperties,
+  componentRatios: TComponentRatios
+): number {
+  return componentRatios !== {}
+    ? Object.entries(componentRatios)
+        .map(([id, ratio]) => componentProperties[id].molecularWeight * ratio)
+        .reduce((a, b) => a + b)
+    : 1
+}
+
 export const FluidDialog = ({
   isOpen,
   close,
@@ -82,6 +93,10 @@ export const FluidDialog = ({
         name: packageName,
         description: packageDescription,
         components: normalizeRatios(componentRatios),
+        molecularWeightSum: computeFeedMolecularWeight(
+          componentProperties,
+          componentRatios
+        ),
       },
     })
     close()

--- a/web/src/components/feature/results/PhaseTable.test.tsx
+++ b/web/src/components/feature/results/PhaseTable.test.tsx
@@ -7,7 +7,7 @@ test('renders without crashing and displaying correct values in table', async ()
   render(
     <PhaseTable
       multiFlashResponse={mockMultiflashResponse}
-      feedFlow={{ unit: 'Sm3/d', value: 0 }}
+      cubicFeedFlow={1000}
     />
   )
   // @ts-ignore because not able to get eslint to discover these types

--- a/web/src/components/feature/results/PhaseTable.tsx
+++ b/web/src/components/feature/results/PhaseTable.tsx
@@ -1,14 +1,17 @@
 import { DynamicTable } from '../../common/DynamicTable'
 import { MultiflashResponse } from '../../../api/generated'
-import { TFeedFlow } from '../../../types'
 import { formatNumber } from '../../../tableUtils'
+import {
+  mercuryMolecularWeight,
+  molePerStandardCubicMeter,
+} from '../../../constants'
 
 function getRows(
   multiFlashResponse: MultiflashResponse,
-  feedFlow: number
+  cubicFeedFlow: number
 ): string[][] {
-  // TODO: Assumes feed flow unit is Sm3/d
-  const phPhaseFlowFactor = feedFlow * 42.29256 * 200.59
+  const phPhaseFlowFactor =
+    cubicFeedFlow * molePerStandardCubicMeter * mercuryMolecularWeight
   const mercury = multiFlashResponse.componentFractions['5']
   return Object.entries(multiFlashResponse.phaseValues).map(
     ([phase, values], index) => [
@@ -23,7 +26,7 @@ function getRows(
 
 export const PhaseTable = (props: {
   multiFlashResponse: MultiflashResponse
-  feedFlow: TFeedFlow
+  cubicFeedFlow: number
 }) => {
   return (
     <DynamicTable
@@ -34,7 +37,7 @@ export const PhaseTable = (props: {
         'Mole Concentration',
         'Mercury Flow (g/d)',
       ]}
-      rows={getRows(props.multiFlashResponse, props.feedFlow.value)}
+      rows={getRows(props.multiFlashResponse, props.cubicFeedFlow)}
       density={'comfortable'}
     />
   )

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -9,6 +9,12 @@ export const authConfig = {
   logoutEndpoint: process.env.REACT_APP_LOGOUT_ENDPOINT || '',
 }
 
+// Molecular weight of mercury
+export const mercuryMolecularWeight = 200.59
+
+// Approximate mole in 1 Sm3 (from ideal gas law with K = 288.15, P=1.01325)
+export const molePerStandardCubicMeter = 42.29256
+
 export const preSelectedComponents: Array<string> = [
   '5',
   '1',

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -9,7 +9,7 @@ import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
 import { PhaseTable } from '../components/feature/results/PhaseTable'
 import { MercuryWarning } from '../components/feature/results/MercuryWarning'
-import { TComponentProperties, TComponentRatios, TFeedFlow } from '../types'
+import { TComponentProperties, TComponentRatios } from '../types'
 
 const Results = styled.div`
   display: flex;
@@ -37,10 +37,8 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const [componentProperties, setComponentProperties] =
     useState<TComponentProperties>()
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [feedFlow, setFeedFlow] = useState<TFeedFlow>({
-    unit: 'Sm3/d',
-    value: 1000,
-  })
+  // feedFlow unit is Sm3/d
+  const [cubicFeedFlow, setCubicFeedFlow] = useState<number>(1000)
   const [usedComponentRatios, setUsedComponentRatios] = useState<
     TComponentRatios | undefined
   >()
@@ -69,8 +67,8 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           mercuryApi={mercuryApi}
           setResult={setResult}
           componentProperties={componentProperties}
-          feedFlow={feedFlow}
-          setFeedFlow={setFeedFlow}
+          cubicFeedFlow={cubicFeedFlow}
+          setCubicFeedFlow={setCubicFeedFlow}
           setUsedComponentRatios={setUsedComponentRatios}
         />
         <DividerWithLargeSpacings />
@@ -83,7 +81,10 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           <>
             {'Mercury' in result.phaseValues && <MercuryWarning />}
             <Results>
-              <PhaseTable multiFlashResponse={result} feedFlow={feedFlow} />
+              <PhaseTable
+                multiFlashResponse={result}
+                cubicFeedFlow={cubicFeedFlow}
+              />
               <MoleTable
                 multiFlashResponse={result}
                 componentProperties={componentProperties}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -12,4 +12,5 @@ export type TPackage = {
   name: string
   description: string
   components: TComponentRatios
+  molecularWeightSum: number
 }


### PR DESCRIPTION
## Why is this pull request needed?
Add support for conversion of feed units.

## What does this pull request change?
User can now convert between units and the conversion will happen in the UI. Unit switch is disabled until a composition feed is selected.

## Issues related to this change:
Closes #80