### PR TITLE
fix: Reset package data on reopening dialog

### DIFF
--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -67,7 +67,7 @@ export const FluidDialog = ({
       setPackageDescription(editablePackage.description)
       setComponentRatios(editablePackage.components)
     }
-  }, [editablePackage])
+  }, [editablePackage, isOpen])
 
   return (
     <WideDialog open={isOpen} onClose={close} isDismissable={true}>


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed to reset dialog state when reopening

## What does this pull request change?

Adds isOpen to useEffect listening list

## Issues related to this change:

Closes #143