### PR TITLE
feat: add sum for component ratios

### DIFF
--- a/web/src/components/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/components/feature/package_dialog/ComponentSelector.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { ComponentTable } from './ComponentTable'
 import { preSelectedComponents } from '../../../constants'
 import { TComponentProperties, TComponentRatios } from '../../../types'
+import { ComponentTableSum } from './ComponentTableSum'
 
 const ComponentSelectorContainer = styled.div`
   display: flex;
@@ -67,6 +68,7 @@ export const ComponentSelector = ({
         componentRatios={componentRatios}
         setComponentRatios={setComponentRatios}
       />
+      <ComponentTableSum componentRatios={componentRatios} />
     </ComponentSelectorContainer>
   )
 }

--- a/web/src/components/feature/package_dialog/ComponentTableSum.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTableSum.tsx
@@ -3,14 +3,10 @@ import { TComponentRatios } from '../../../types'
 import { formatNumber } from '../../../tableUtils'
 
 function computeComponentRatioSum(componentRatios: TComponentRatios) {
-  if (Object.keys(componentRatios).length > 0) {
-    return formatNumber(
-      Object.values(componentRatios).reduce((a, b) => a + b),
-      3
-    )
-  } else {
-    return 0
-  }
+  return formatNumber(
+    Object.values(componentRatios).reduce((a, b) => a + b, 0),
+    3
+  )
 }
 
 export const ComponentTableSum = ({

--- a/web/src/components/feature/package_dialog/ComponentTableSum.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTableSum.tsx
@@ -1,0 +1,33 @@
+import { EdsProvider, Table } from '@equinor/eds-core-react'
+import { TComponentRatios } from '../../../types'
+import { formatNumber } from '../../../tableUtils'
+
+function computeComponentRatioSum(componentRatios: TComponentRatios) {
+  if (Object.keys(componentRatios).length > 0) {
+    return formatNumber(
+      Object.values(componentRatios).reduce((a, b) => a + b),
+      3
+    )
+  } else {
+    return 0
+  }
+}
+
+export const ComponentTableSum = ({
+  componentRatios,
+}: {
+  componentRatios: TComponentRatios
+}): JSX.Element => {
+  return (
+    <EdsProvider density={'compact'}>
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{`Component sum`}</Table.Cell>
+            <Table.Cell>{computeComponentRatioSum(componentRatios)}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </EdsProvider>
+  )
+}


### PR DESCRIPTION
## Why is this pull request needed?
Checksum to see if the component inputs are in the desired range.

## What does this pull request change?
Adds a row with the sum of the components at the bottom of componentselector.

## Issues related to this change:
closes #148 