### PR TITLE
fix: Rerender dialog on opening

### DIFF
--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -48,13 +48,13 @@ export const CalculationInput = ({
   setCubicFeedFlow: (cubicFeedFlow: number) => void
   setUsedComponentRatios: (ratios: TComponentRatios) => void
 }) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [isNewOpen, setIsNewOpen] = useState<boolean>(false)
+  const [isEditOpen, setIsEditOpen] = useState<boolean>(false)
   const [temperature, setTemperature] = useState<number>(15)
   const [pressure, setPressure] = useState<number>(1)
   const [calculating, setCalculating] = useState<boolean>(false)
   const [packages, setPackages] = useLocalStorage<TPackage[]>('packages', [])
   const [selectedPackage, setSelectedPackage] = useState<TPackage | undefined>()
-  const [editablePackage, setEditablePackage] = useState<TPackage | undefined>()
 
   const calculate = (
     <Button
@@ -92,10 +92,10 @@ export const CalculationInput = ({
     </Button>
   )
 
-  const savePackage = (newPackage: TPackage) => {
+  const savePackage = (newPackage: TPackage, mode: 'new' | 'edit') => {
     let oldPackages = [...packages]
-    if (editablePackage !== undefined) {
-      oldPackages = oldPackages.filter((x) => x.name !== editablePackage.name)
+    if (mode === 'edit' && selectedPackage !== undefined) {
+      oldPackages = oldPackages.filter((x) => x.name !== selectedPackage.name)
     }
     if (oldPackages.find((x) => x.name === newPackage.name)) {
       oldPackages = oldPackages.filter((x) => x.name !== newPackage.name)
@@ -121,21 +121,12 @@ export const CalculationInput = ({
             />
             <Button
               variant="outlined"
-              onClick={() => {
-                setEditablePackage(selectedPackage)
-                setIsOpen(true)
-              }}
+              onClick={() => setIsEditOpen(true)}
               disabled={selectedPackage === undefined}
             >
               Edit
             </Button>
-            <Button
-              variant="outlined"
-              onClick={() => {
-                setEditablePackage(undefined)
-                setIsOpen(true)
-              }}
-            >
+            <Button variant="outlined" onClick={() => setIsNewOpen(true)}>
               New
             </Button>
           </FluidPackage>
@@ -158,13 +149,21 @@ export const CalculationInput = ({
           />
         </Form>
       </Card>
-      <FluidDialog
-        isOpen={isOpen}
-        close={() => setIsOpen(false)}
-        componentProperties={componentProperties}
-        editablePackage={editablePackage}
-        savePackage={savePackage}
-      />
+      {isNewOpen && (
+        <FluidDialog
+          close={() => setIsNewOpen(false)}
+          componentProperties={componentProperties}
+          savePackage={(x) => savePackage(x, 'new')}
+        />
+      )}
+      {isEditOpen && (
+        <FluidDialog
+          close={() => setIsEditOpen(false)}
+          componentProperties={componentProperties}
+          editablePackage={selectedPackage}
+          savePackage={(x) => savePackage(x, 'edit')}
+        />
+      )}
     </>
   )
 }

--- a/web/src/components/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/components/feature/package_dialog/ComponentSelector.tsx
@@ -36,9 +36,9 @@ export const ComponentSelector = ({
       id: key,
     })
   )
-  const initials = options.filter((option) =>
-    preSelectedComponents.includes(option.id)
-  )
+  const initials = Object.keys(componentRatios).length
+    ? options.filter((option) => componentRatios[option.id])
+    : options.filter((option) => preSelectedComponents.includes(option.id))
   const [selectedComponents, setSelectedComponents] =
     useState<TComponentProperty[]>(initials)
   return (

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { Button, Dialog, TextField } from '@equinor/eds-core-react'
 import { ComponentSelector } from './ComponentSelector'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   TPackage,
   TComponentProperties,
@@ -40,37 +40,29 @@ function computeFeedMolecularWeight(
 }
 
 export const FluidDialog = ({
-  isOpen,
   close,
   componentProperties,
   editablePackage,
   savePackage,
 }: {
-  isOpen: boolean
   close: () => void
   componentProperties: TComponentProperties
-  editablePackage: TPackage | undefined
+  editablePackage?: TPackage
   savePackage: (x: TPackage) => void
 }) => {
   // Array of components containing input from user
-  const [componentRatios, setComponentRatios] = useState<TComponentRatios>({})
-  const [packageName, setPackageName] = useState<string>('')
-  const [packageDescription, setPackageDescription] = useState<string>('')
-
-  useEffect(() => {
-    if (editablePackage === undefined) {
-      setPackageName('')
-      setPackageDescription('')
-      setComponentRatios({})
-    } else {
-      setPackageName(editablePackage.name)
-      setPackageDescription(editablePackage.description)
-      setComponentRatios(editablePackage.components)
-    }
-  }, [editablePackage, isOpen])
+  const [componentRatios, setComponentRatios] = useState<TComponentRatios>(
+    editablePackage?.components ?? {}
+  )
+  const [packageName, setPackageName] = useState<string>(
+    editablePackage?.name ?? ''
+  )
+  const [packageDescription, setPackageDescription] = useState<string>(
+    editablePackage?.description ?? ''
+  )
 
   return (
-    <WideDialog open={isOpen} onClose={close} isDismissable={true}>
+    <WideDialog open onClose={close} isDismissable>
       <Dialog.Header>
         <Dialog.Title>Create fluid package</Dialog.Title>
       </Dialog.Header>


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because we'd want the components with value to show in dialog when opening, not the defaults

## What does this pull request change?

- Dialog becomes more predictable if the entire dialog rerenders on opening. I've therefore wrapped it in a conditional and removed the isOpen input parameter
- I found a more intuitive solution the new/edit mode that allows me to remove editablePackage from CalculationInput. This also removes the danger of a race condition between isOpen and editablePackage
- Set autocomplete initials to depend on the componentRatios object

## Issues related to this change:

Closes #145