### PR TITLE
refactor: Remove unused usedComponentRatios state

### DIFF
--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -7,11 +7,7 @@ import { MultiflashResponse } from '../../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../../api/MercuryAPI'
 import { FeedFlowInput } from './FeedFlowInput'
-import {
-  TComponentProperties,
-  TComponentRatios,
-  TPackage,
-} from '../../../types'
+import { TComponentProperties, TPackage } from '../../../types'
 import useLocalStorage from '../../../hooks/useLocalStorage'
 import { TempOrPressureInput } from './TempOrPressureInput'
 
@@ -39,14 +35,12 @@ export const CalculationInput = ({
   componentProperties,
   cubicFeedFlow,
   setCubicFeedFlow,
-  setUsedComponentRatios,
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: MultiflashResponse) => void
   componentProperties: TComponentProperties
   cubicFeedFlow: number
   setCubicFeedFlow: (cubicFeedFlow: number) => void
-  setUsedComponentRatios: (ratios: TComponentRatios) => void
 }) => {
   const [isNewOpen, setIsNewOpen] = useState<boolean>(false)
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false)
@@ -63,7 +57,6 @@ export const CalculationInput = ({
       onClick={() => {
         if (selectedPackage === undefined) return
         setCalculating(true)
-        setUsedComponentRatios(selectedPackage.components)
         mercuryApi
           .computeMultiflash({
             multiflash: {

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -9,7 +9,7 @@ import { AxiosResponse } from 'axios'
 import { ComponentResponse, MultiflashResponse } from '../api/generated'
 import { PhaseTable } from '../components/feature/results/PhaseTable'
 import { MercuryWarning } from '../components/feature/results/MercuryWarning'
-import { TComponentProperties, TComponentRatios } from '../types'
+import { TComponentProperties } from '../types'
 
 const Results = styled.div`
   display: flex;
@@ -39,9 +39,6 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(true)
   // feedFlow unit is Sm3/d
   const [cubicFeedFlow, setCubicFeedFlow] = useState<number>(1000)
-  const [usedComponentRatios, setUsedComponentRatios] = useState<
-    TComponentRatios | undefined
-  >()
   const [result, setResult] = useState<MultiflashResponse>()
 
   // Fetch list of components name once on page load
@@ -69,7 +66,6 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           componentProperties={componentProperties}
           cubicFeedFlow={cubicFeedFlow}
           setCubicFeedFlow={setCubicFeedFlow}
-          setUsedComponentRatios={setUsedComponentRatios}
         />
         <DividerWithLargeSpacings />
         {!result && (
@@ -77,7 +73,7 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
             Run a calculation to get results
           </Typography>
         )}
-        {result && usedComponentRatios && (
+        {result && (
           <>
             {'Mercury' in result.phaseValues && <MercuryWarning />}
             <Results>


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Removes the unused usedComponentRatios state. The state was supposed to tell the moletable which feed ratios had been used in the calculation. Its use was removed in #134, as a result of the normalized ratios being returned by the API, but its declaration remained.

## Issues related to this change:

Cleanup after #130