### PR TITLE
fix: use Input in ComponentTable

### DIFF
--- a/web/src/components/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTable.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { EdsProvider, Table, TextField } from '@equinor/eds-core-react'
+import { EdsProvider, Input, Table } from '@equinor/eds-core-react'
 import { TComponentRatios, TComponentProperties } from '../../../types'
 
 const ComponentTableContainer = styled.div`
@@ -26,9 +26,9 @@ export const ComponentTable = ({
           data-testid={`Component-${index}`}
         >{`${names.altName} (${names.chemicalFormula})`}</Table.Cell>
         <Table.Cell data-testid={`Ratio (mol)-${index}`}>
-          <TextField
+          <Input
             id={`${names.chemicalFormula}-input`}
-            value={(componentRatios[id] ?? 0).toString()}
+            value={componentRatios[id] ?? 0}
             min={0}
             type="number"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Why is this pull request needed?
To accept decimalnumbers on format 0.01

## What does this pull request change?
Changed from Textfield to Input in ComponentTable. 
Removed toString(). 

## Issues related to this change:
#157 