### PR TITLE
fix: app handles zero mercury

### DIFF
--- a/web/src/components/feature/results/PhaseTable.tsx
+++ b/web/src/components/feature/results/PhaseTable.tsx
@@ -9,7 +9,9 @@ import { TResults } from '../../../types'
 function getRows(results: TResults): string[][] {
   const phPhaseFlowFactor =
     results.cubicFeedFlow * molePerStandardCubicMeter * mercuryMolecularWeight
-  const mercury = results.componentFractions['5']
+  const mercury =
+    results.componentFractions['5'] ??
+    Array(Object.keys(results.phaseValues).length).fill(0)
   return Object.entries(results.phaseValues).map(([phase, values], index) => [
     phase,
     formatNumber(values['percentage']),


### PR DESCRIPTION
## Why is this pull request needed?
App crash for zero mercury.

## What does this pull request change?
Defaults zero mercury to array of zeros. Could be discussed how meaningful the output is and if it is perhaps better to give a warning about how mercury is zero and disallow computation?

## Issues related to this change:
Closes #142