### PR TITLE
refactor: Rename ComponentSelector header to Mole Fractions

### DIFF
--- a/web/src/components/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTable.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { EdsProvider, Input, Table } from '@equinor/eds-core-react'
-import { TComponentRatios, TComponentProperties } from '../../../types'
+import { TComponentProperties, TComponentRatios } from '../../../types'
 
 const ComponentTableContainer = styled.div`
   display: flex;
@@ -55,9 +55,7 @@ export const ComponentTable = ({
           <Table.Head sticky>
             <Table.Row>
               <Table.Cell key={`Component`}>{`Component`}</Table.Cell>
-              <Table.Cell
-                key={`Feed value (mol)`}
-              >{`Feed value (mol)`}</Table.Cell>
+              <Table.Cell key={`Mole fractions`}>{`Mole fractions`}</Table.Cell>
             </Table.Row>
           </Table.Head>
           <Table.Body>{createTableRows()}</Table.Body>


### PR DESCRIPTION
## Why is this pull request needed?
Rename table header.

## What does this pull request change?
Just that.

## Issues related to this change:
Closes #94