### PR TITLE
chore: Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Each line is a file pattern followed by one or more owners.
+# Order matter. If two rules match the same file, only the last one is used
+
+# Repo owners
+*       @rikkebl @ingeridhellen @mariuswinger @soofstad
+
+# API owners
+/api/   @mariuswinger @soofstad


### PR DESCRIPTION
## Why is this pull request needed?

To simplify creating a PR

## What does this pull request change?

Sets Rikke, Marius, Stig and Ingerid as codeowners for all files, except the API, where only Stig and Marius are codeowners

## Issues related to this change: