### PR TITLE
fix: styling in fluidDialog. Align component input to right

### DIFF
--- a/web/src/components/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/components/feature/package_dialog/ComponentSelector.tsx
@@ -10,7 +10,7 @@ const ComponentSelectorContainer = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: 4px;
-  max-width: 500px;
+  max-width: 420px;
 `
 
 type TComponentProperty = {

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -22,12 +22,14 @@ const FluidPackageForm = styled.div`
   display: flex;
   flex-flow: row wrap;
   gap: 30px;
+  justify-content: space-between;
 `
 
 const FirstColumn = styled.div`
   display: flex;
   flex-flow: column nowrap;
   gap: 30px;
+  width: 40%;
 `
 
 const ButtonRow = styled.div`
@@ -98,6 +100,7 @@ export const FluidDialog = ({
                 setPackageDescription(event.target.value)
               }
               multiline
+              rows={6}
             />
           </FirstColumn>
           <ComponentSelector


### PR DESCRIPTION
## Why is this pull request needed?

Making the app look better

## What does this pull request change?

- Bigger input fields for FluidPackage name and descsription
- Align ComponentSelector to right

## Issues related to this change:
closes #163 
![Screenshot_20221104_094128](https://user-images.githubusercontent.com/11062560/199930282-2f31d114-5bd0-4b32-bc73-781e5b12b245.png)

