### PR TITLE
feature: warn user before overwriting existing package

### DIFF
--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -95,7 +95,7 @@ export const CalculationInput = ({
     const packageNameConflict = oldPackages.find(
       (x) => x.name === newPackage?.name
     )
-    if (mode === 'new' && packageNameConflict) {
+    if (packageNameConflict) {
       const overwrite: boolean = window.confirm(
         `A package named '${newPackage?.name}' already exists.\nOk to overwrite?`
       )

--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -91,6 +91,16 @@ export const CalculationInput = ({
     if (mode === 'edit' && selectedPackage !== undefined) {
       oldPackages = oldPackages.filter((x) => x.name !== selectedPackage.name)
     }
+
+    const packageNameConflict = oldPackages.find(
+      (x) => x.name === newPackage?.name
+    )
+    if (mode === 'new' && packageNameConflict) {
+      const overwrite: boolean = window.confirm(
+        `A package named '${newPackage?.name}' already exists.\nOk to overwrite?`
+      )
+      if (!overwrite) return
+    }
     oldPackages = oldPackages.filter((x) => x.name !== newPackage?.name)
     setSelectedPackage(newPackage)
     setPackages(newPackage ? [...oldPackages, newPackage] : oldPackages)


### PR DESCRIPTION
## Why is this pull request needed?

User should be warned before any potential destructive actions

## What does this pull request change?

Prompt the user for a confirmation before overriding a FluidPackage with a new one

## Issues related to this change:
closes #161 