### PR TITLE
feature(web): toggle precision in Moletable

### DIFF
--- a/web/src/components/feature/results/MoleTable.tsx
+++ b/web/src/components/feature/results/MoleTable.tsx
@@ -1,16 +1,29 @@
 import { DynamicTable } from '../../common/DynamicTable'
 import { formatNumber } from '../../../tableUtils'
 import { TComponentProperties, TResults } from '../../../types'
+import { useState } from 'react'
+import { Switch } from '@equinor/eds-core-react'
+import styled from 'styled-components'
+
+const MoleTableWrapper = styled.div`
+  text-align: right;
+`
 
 function getRows(
   results: TResults,
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperties,
+  fullPrecision: boolean
 ): string[][] {
   return Object.entries(results.componentFractions).map(
     ([compId, fractions]) => [
       componentProperties[compId].altName,
-      formatNumber(results.feedFractions[compId]),
-      ...fractions.map((x) => formatNumber(x, 2, 3)),
+      fullPrecision
+        ? results.feedFractions[compId].toString()
+        : formatNumber(results.feedFractions[compId]),
+      ...fractions.map((x) => {
+        if (fullPrecision) return x.toString()
+        return formatNumber(x, 2, 3)
+      }),
     ]
   )
 }
@@ -20,17 +33,25 @@ export const MoleTable = (props: {
   results: TResults
   componentProperties: TComponentProperties
 }) => {
+  const [fullPrecision, setFullPrecision] = useState<boolean>(false)
   return (
-    <DynamicTable
-      headers={[
-        'Components',
-        'Feed ratio',
-        ...Object.keys(props.results.phaseValues).map(
-          (phase) => `${phase} (mol)`
-        ),
-      ]}
-      rows={getRows(props.results, props.componentProperties)}
-      density={'compact'}
-    />
+    <MoleTableWrapper>
+      <DynamicTable
+        headers={[
+          'Components',
+          'Feed ratio',
+          ...Object.keys(props.results.phaseValues).map(
+            (phase) => `${phase} (mol)`
+          ),
+        ]}
+        rows={getRows(props.results, props.componentProperties, fullPrecision)}
+        density={'compact'}
+      />
+      <Switch
+        label="full precision"
+        checked={fullPrecision}
+        onChange={(event) => setFullPrecision(event.target.checked)}
+      />
+    </MoleTableWrapper>
   )
 }


### PR DESCRIPTION
## Why is this pull request needed?

Some users might want to do a quality control on the results, and need higher precision 

## What does this pull request change?

- Added a switch to control whether to format numbers in the MoleResult table
![Screenshot_20221104_154900](https://user-images.githubusercontent.com/11062560/200004885-5f1e43cd-efc7-4a89-828f-930a92183ef1.png)


## Issues related to this change:
closes #186 