### PR TITLE
feature(web): be able to use existing packages as templates

### DIFF
--- a/web/src/components/common/Header.tsx
+++ b/web/src/components/common/Header.tsx
@@ -99,7 +99,7 @@ export const Header = (): JSX.Element => {
             color={'secondary'}
             variant={'outlined'}
           >
-            Reset application
+            Reset application data
           </Button>
         </Popover.Actions>
       </Popover>

--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -156,6 +156,7 @@ export const CalculationInput = ({
           close={() => setIsNewOpen(false)}
           componentProperties={componentProperties}
           savePackage={(x) => savePackage('new', x)}
+          packages={packages}
         />
       )}
       {isEditOpen && (
@@ -164,6 +165,7 @@ export const CalculationInput = ({
           componentProperties={componentProperties}
           editablePackage={selectedPackage}
           savePackage={(x) => savePackage('edit', x)}
+          packages={packages}
         />
       )}
     </>

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -77,8 +77,6 @@ export const FluidDialog = ({
     [id: string]: boolean
   }>({})
 
-  const [selectedPackage, setSelectedPackage] = useState<TPackage | undefined>()
-
   return (
     <WideDialog open onClose={close} isDismissable>
       <Dialog.Header>
@@ -118,9 +116,7 @@ export const FluidDialog = ({
               optionLabel={(option) => option.name}
               onOptionsChange={(changes) => {
                 setComponentRatios(changes.selectedItems[0].components)
-                setSelectedPackage(changes.selectedItems[0])
               }}
-              selectedOptions={selectedPackage ? [selectedPackage] : []}
               autoWidth
             />
           </FirstColumn>

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -1,5 +1,11 @@
 import styled from 'styled-components'
-import { Button, Dialog, TextField, Typography } from '@equinor/eds-core-react'
+import {
+  Button,
+  Dialog,
+  TextField,
+  Typography,
+  Autocomplete,
+} from '@equinor/eds-core-react'
 import { tokens } from '@equinor/eds-tokens'
 import { ComponentSelector } from './ComponentSelector'
 import { useState } from 'react'
@@ -49,11 +55,13 @@ export const FluidDialog = ({
   componentProperties,
   editablePackage,
   savePackage,
+  packages,
 }: {
   close: () => void
   componentProperties: TComponentProperties
   editablePackage?: TPackage
   savePackage: (x?: TPackage) => void
+  packages: TPackage[]
 }) => {
   // Array of components containing input from user
   const [componentRatios, setComponentRatios] = useState<TComponentRatios>(
@@ -68,6 +76,8 @@ export const FluidDialog = ({
   const [ratiosAreValid, setRatiosAreValid] = useState<{
     [id: string]: boolean
   }>({})
+
+  const [selectedPackage, setSelectedPackage] = useState<TPackage | undefined>()
 
   return (
     <WideDialog open onClose={close} isDismissable>
@@ -101,6 +111,17 @@ export const FluidDialog = ({
               }
               multiline
               rows={6}
+            />
+            <Autocomplete
+              label="Template"
+              options={packages}
+              optionLabel={(option) => option.name}
+              onOptionsChange={(changes) => {
+                setComponentRatios(changes.selectedItems[0].components)
+                setSelectedPackage(changes.selectedItems[0])
+              }}
+              selectedOptions={selectedPackage ? [selectedPackage] : []}
+              autoWidth
             />
           </FirstColumn>
           <ComponentSelector


### PR DESCRIPTION
## Why is this pull request needed?

Users want to create fluid packages that are almost similar, templates are a solution for that.

## What does this pull request change?
Adds a dropdown for selecting packages as a template when creating a new, or editing a package

![Screenshot_20221107_101617](https://user-images.githubusercontent.com/11062560/200273053-9e79d9a6-2601-4526-8519-db6ce55f4544.png)


## Issues related to this change:
closes #188 