### PR TITLE
feature(api): expose metrics

### DIFF
--- a/api/src/features/component/component_feature.py
+++ b/api/src/features/component/component_feature.py
@@ -4,6 +4,7 @@ from starlette.responses import JSONResponse
 from common.components import COMPONENTS
 from common.responses import create_response
 from entities.ComponentResponse import ComponentResponse
+from features.metrics.metrics_feature import metrics
 
 router = APIRouter(tags=["component"])
 
@@ -11,4 +12,5 @@ router = APIRouter(tags=["component"])
 @create_response(JSONResponse)
 @router.get("/components", operation_id="get_components", response_model=ComponentResponse)
 async def components() -> ComponentResponse:
+    metrics.FETCH_COMPONENTS_COUNT += 1
     return ComponentResponse(components=COMPONENTS)

--- a/api/src/features/metrics/metrics_feature.py
+++ b/api/src/features/metrics/metrics_feature.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+from config import config
+
+router = APIRouter(tags=["metrics"])
+
+
+class Metrics:
+    MULTIFLASH_CALCULATION_COUNT: int = 0
+    FETCH_COMPONENTS_COUNT: int = 0
+
+
+metrics = Metrics()
+
+
+@router.get("/metrics", response_class=PlainTextResponse, summary="Collect application metrics", response_model=str)
+async def get() -> str:
+    return f"""mercury_calculations_count {{env={config.ENVIRONMENT}}} {metrics.MULTIFLASH_CALCULATION_COUNT}\n
+mercury_fetch_components_count {{env={config.ENVIRONMENT}}} {metrics.FETCH_COMPONENTS_COUNT}\n"""

--- a/api/src/features/multiflash/multiflash_feature.py
+++ b/api/src/features/multiflash/multiflash_feature.py
@@ -3,6 +3,7 @@ from starlette.responses import JSONResponse
 
 from common.responses import create_response
 from entities.Multiflash import Multiflash
+from features.metrics.metrics_feature import metrics
 from features.multiflash.multiflash_use_case import (
     MultiflashResponse,
     compute_multiflash_use_case,
@@ -14,4 +15,5 @@ router = APIRouter(tags=["multiflash"])
 @create_response(JSONResponse)
 @router.post("/multiflash", operation_id="compute_multiflash", response_model=MultiflashResponse)
 async def compute_multiflash(multiflash: Multiflash) -> MultiflashResponse:
+    metrics.MULTIFLASH_CALCULATION_COUNT += 1
     return compute_multiflash_use_case(multiflash=multiflash)

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -29,7 +29,9 @@ spec:
       environmentConfig:
         - environment: prod
           imageTagName: production
+          monitoring: true
         - environment: dev
+          monitoring: true
           imageTagName: latest
       variables:
         LOGGING_LEVEL: "debug"


### PR DESCRIPTION
## Why is this pull request needed?

PO wants to be able to see usage statistics of the tool

## What does this pull request change?

Adds a `/metrics` endpoint in according to https://www.radix.equinor.com/guides/monitoring/#metrics-visualisation.

NOTE: Consider this a test/proof-of-concept.
This is a very primitive light weight solution, the "count" metric type that is now exported might not be a good fit.
Would like to get this into radix and see how it looks.

## Issues related to this change:

related to #183  but not closing it yet...