### PR TITLE
fix: Fix component table order

### DIFF
--- a/web/src/components/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/components/feature/package_dialog/ComponentSelector.tsx
@@ -13,13 +13,6 @@ const ComponentSelectorContainer = styled.div`
   max-width: 420px;
 `
 
-type TComponentProperty = {
-  name: string
-  formula: string
-  weight: number
-  id: string
-}
-
 export const ComponentSelector = ({
   componentProperties,
   componentRatios,
@@ -33,19 +26,13 @@ export const ComponentSelector = ({
   ratiosAreValid: { [id: string]: boolean }
   setRatiosAreValid: (x: { [id: string]: boolean }) => void
 }) => {
-  const options: TComponentProperty[] = Object.entries(componentProperties).map(
-    ([key, entry]) => ({
-      name: entry.altName,
-      formula: entry.chemicalFormula,
-      weight: entry.molecularWeight,
-      id: key,
-    })
-  )
   const initials = Object.keys(componentRatios).length
-    ? options.filter((option) => componentRatios[option.id])
-    : options.filter((option) => preSelectedComponents.includes(option.id))
+    ? componentProperties.filter((option) => componentRatios[option.id])
+    : componentProperties.filter((option) =>
+        preSelectedComponents.includes(option.id)
+      )
   const [selectedComponents, setSelectedComponents] =
-    useState<TComponentProperty[]>(initials)
+    useState<TComponentProperties>(initials)
   return (
     <ComponentSelectorContainer>
       <Autocomplete
@@ -68,21 +55,14 @@ export const ComponentSelector = ({
         }}
         label="Add components"
         multiple
-        options={options}
+        options={componentProperties}
         initialSelectedOptions={initials}
-        optionLabel={(option) => `${option.name} (${option.formula})`}
+        optionLabel={(option) =>
+          `${option.altName} (${option.chemicalFormula})`
+        }
       />
       <ComponentTable
-        selectedComponents={Object.fromEntries(
-          selectedComponents.map((x) => [
-            x.id,
-            {
-              altName: x.name,
-              chemicalFormula: x.formula,
-              molecularWeight: x.weight,
-            },
-          ])
-        )}
+        selectedComponents={selectedComponents}
         componentRatios={componentRatios}
         setComponentRatios={setComponentRatios}
         ratiosAreValid={ratiosAreValid}

--- a/web/src/components/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTable.tsx
@@ -25,29 +25,31 @@ export const ComponentTable = ({
   setRatiosAreValid: (x: { [id: string]: boolean }) => void
 }): JSX.Element => {
   function createTableRows() {
-    return Object.entries(selectedComponents).map(([id, names], rowIndex) => (
+    return selectedComponents.map((component, rowIndex) => (
       <Table.Row key={rowIndex}>
         <Table.Cell
           data-testid={`Component-${rowIndex}`}
-        >{`${names.altName} (${names.chemicalFormula})`}</Table.Cell>
+        >{`${component.altName} (${component.chemicalFormula})`}</Table.Cell>
         <Table.Cell data-testid={`Ratio (mol)-${rowIndex}`}>
           <Input
-            id={`${names.chemicalFormula}-input`}
-            value={componentRatios[id] ?? ''}
+            id={`${component.chemicalFormula}-input`}
+            value={componentRatios[component.id] ?? ''}
             pattern="^\d+(\.\d+)?([eE][-+]?\d+)?$"
-            variant={ratiosAreValid[id] === false ? 'warning' : undefined}
+            variant={
+              ratiosAreValid[component.id] === false ? 'warning' : undefined
+            }
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               const newRatiosAreValid = { ...ratiosAreValid }
-              newRatiosAreValid[id] =
+              newRatiosAreValid[component.id] =
                 event.target.checkValidity() &&
                 !isNaN(Number(event.target.value))
               setRatiosAreValid(newRatiosAreValid)
 
               const newRatios = { ...componentRatios }
               if (event.target.value === '') {
-                delete newRatios[id]
+                delete newRatios[component.id]
               } else {
-                newRatios[id] = event.target.value
+                newRatios[component.id] = event.target.value
               }
               setComponentRatios(newRatios)
             }}

--- a/web/src/components/feature/package_dialog/SaveButton.tsx
+++ b/web/src/components/feature/package_dialog/SaveButton.tsx
@@ -13,7 +13,8 @@ function computeFeedMolecularWeight(
     ? Object.entries(componentRatios)
         .map(
           ([id, ratio]) =>
-            componentProperties[id].molecularWeight * Number(ratio)
+            Number(ratio) *
+            (componentProperties.find((x) => x.id === id)?.molecularWeight ?? 0)
         )
         .reduce((a, b) => a + b)
     : 1

--- a/web/src/components/feature/results/MoleTable.tsx
+++ b/web/src/components/feature/results/MoleTable.tsx
@@ -16,7 +16,7 @@ function getRows(
 ): string[][] {
   return Object.entries(results.componentFractions).map(
     ([compId, fractions]) => [
-      componentProperties[compId].altName,
+      componentProperties.find((x) => x.id === compId)?.altName ?? '',
       fullPrecision
         ? results.feedFractions[compId].toString()
         : formatNumber(results.feedFractions[compId]),

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -44,7 +44,12 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
     mercuryApi
       .getComponents()
       .then((response: AxiosResponse<ComponentResponse>) =>
-        setComponentProperties(response.data.components)
+        setComponentProperties(
+          Object.entries(response.data.components).map(([id, data]) => ({
+            id: id,
+            ...data,
+          }))
+        )
       )
       .finally(() => setIsLoading(false))
   }, [mercuryApi])

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -74,130 +74,179 @@ export const mockResults: TResults = {
   cubicFeedFlow: 1000,
 }
 
-export const mockComponentProperties: TComponentProperties = {
-  '1': {
+export const mockComponentProperties: TComponentProperties = [
+  {
+    id: '1',
     chemicalFormula: 'CO2',
     altName: 'Carbondioxide',
     molecularWeight: 44.01,
   },
-  '2': { chemicalFormula: 'N2', altName: 'Nitrogen', molecularWeight: 28.014 },
-  '3': { chemicalFormula: 'H2O', altName: 'Water', molecularWeight: 18.015 },
-  '4': {
+  {
+    id: '2',
+    chemicalFormula: 'N2',
+    altName: 'Nitrogen',
+    molecularWeight: 28.014,
+  },
+  {
+    id: '3',
+    chemicalFormula: 'H2O',
+    altName: 'Water',
+    molecularWeight: 18.015,
+  },
+  {
+    id: '4',
     chemicalFormula: 'H2S',
     altName: 'Hydrogensulfide',
     molecularWeight: 34.082,
   },
-  '5': { chemicalFormula: 'Hg', altName: 'Mercury', molecularWeight: 200.59 },
-  '101': {
+  {
+    id: '5',
+    chemicalFormula: 'Hg',
+    altName: 'Mercury',
+    molecularWeight: 200.59,
+  },
+  {
+    id: '101',
     chemicalFormula: 'CH4',
     altName: 'Methane',
     molecularWeight: 16.043,
   },
-  '201': { chemicalFormula: 'C2H6', altName: 'Ethane', molecularWeight: 30.07 },
-  '301': {
+  {
+    id: '201',
+    chemicalFormula: 'C2H6',
+    altName: 'Ethane',
+    molecularWeight: 30.07,
+  },
+  {
+    id: '301',
     chemicalFormula: 'nC3',
     altName: 'Propane',
     molecularWeight: 44.096,
   },
-  '401': {
+  {
+    id: '401',
     chemicalFormula: 'iC4',
     altName: 'i-Butane',
     molecularWeight: 58.123,
   },
-  '402': {
+  {
+    id: '402',
     chemicalFormula: 'nC4',
     altName: 'n-Butane',
     molecularWeight: 58.123,
   },
-  '501': {
+  {
+    id: '501',
     chemicalFormula: '22-dm-C3',
     altName: '2-2-dimethyl-propane',
     molecularWeight: 72.15,
   },
-  '503': {
+  {
+    id: '503',
     chemicalFormula: 'iC5',
     altName: 'i-Pentane',
     molecularWeight: 70.134,
   },
-  '504': {
+  {
+    id: '504',
     chemicalFormula: 'nC5',
     altName: 'n-Pentane',
     molecularWeight: 72.15,
   },
-  '502': { chemicalFormula: 'cy-C5', altName: 'Cy-C5', molecularWeight: 72.15 },
-  '601': {
+  {
+    id: '502',
+    chemicalFormula: 'cy-C5',
+    altName: 'Cy-C5',
+    molecularWeight: 72.15,
+  },
+  {
+    id: '601',
     chemicalFormula: '22-dm-C4',
     altName: '2-2-dimethyl-butane(neohexane)',
     molecularWeight: 86.177,
   },
-  '602': {
+  {
+    id: '602',
     chemicalFormula: '23-dm-C4',
     altName: '2-3-dimethyl-butane',
     molecularWeight: 86.177,
   },
-  '603': {
+  {
+    id: '603',
     chemicalFormula: '2-m-C5',
     altName: '2-methyl-pentane',
     molecularWeight: 86.177,
   },
-  '604': {
+  {
+    id: '604',
     chemicalFormula: '3-m-C5',
     altName: '3-methyl-pentane',
     molecularWeight: 86.177,
   },
-  '605': {
+  {
+    id: '605',
     chemicalFormula: 'nC6',
     altName: 'n-Hexane',
     molecularWeight: 86.177,
   },
-  '606': {
+  {
+    id: '606',
     chemicalFormula: 'cy-C6',
     altName: 'Cy-hexane',
     molecularWeight: 84.161,
   },
-  '608': {
+  {
+    id: '608',
     chemicalFormula: 'benzene',
     altName: 'Benzene',
     molecularWeight: 78.114,
   },
-  '701': {
+  {
+    id: '701',
     chemicalFormula: 'nC7',
     altName: 'n-heptane',
     molecularWeight: 100.204,
   },
-  '707': {
+  {
+    id: '707',
     chemicalFormula: 'cy-C7',
     altName: 'Cy-heptane',
     molecularWeight: 98.188,
   },
-  '710': {
+  {
+    id: '710',
     chemicalFormula: 'toluene',
     altName: 'Toluene',
     molecularWeight: 92.141,
   },
-  '801': {
+  {
+    id: '801',
     chemicalFormula: 'nC8',
     altName: 'n-octane',
     molecularWeight: 114.231,
   },
-  '806': {
+  {
+    id: '806',
     chemicalFormula: 'cy-C8',
     altName: 'Cy-octane',
     molecularWeight: 112.215,
   },
-  '809': {
+  {
+    id: '809',
     chemicalFormula: 'm-xylene',
     altName: 'M-xylene',
     molecularWeight: 106.167,
   },
-  '901': {
+  {
+    id: '901',
     chemicalFormula: 'nC9',
     altName: 'n-nonane',
     molecularWeight: 128.258,
   },
-  '1016': {
+  {
+    id: '1016',
     chemicalFormula: 'nC10',
     altName: 'n-decane',
     molecularWeight: 142.285,
   },
-}
+]

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,8 +1,8 @@
 import { ComponentProperties, MultiflashResponse } from './api/generated'
 
-export type TComponentProperties = {
-  [id: string]: ComponentProperties
-}
+export type TComponentProperties = (ComponentProperties & {
+  id: string
+})[]
 export type TResults = MultiflashResponse & {
   cubicFeedFlow: number
 }


### PR DESCRIPTION
## Why is this pull request needed?

Eleni wants the order of the components table to be determined by the order they were added

## What does this pull request change?

Fixed by switching TComponentProperties from object to array

## Issues related to this change:

Closes #201