### PR TITLE
fix: Avoid both popovers open at once

### DIFF
--- a/web/src/components/common/Header.tsx
+++ b/web/src/components/common/Header.tsx
@@ -51,7 +51,10 @@ export const Header = (): JSX.Element => {
           <Icons>
             <Button
               variant="ghost_icon"
-              onClick={() => setUserInfoOpen(!isUserInfoOpen)}
+              onClick={() => {
+                setUserInfoOpen(!isUserInfoOpen)
+                setAboutOpen(false)
+              }}
               id="account-anchor"
               ref={accountRefElement}
             >
@@ -59,7 +62,10 @@ export const Header = (): JSX.Element => {
             </Button>
             <Button
               variant="ghost_icon"
-              onClick={() => setAboutOpen(!isAboutOpen)}
+              onClick={() => {
+                setUserInfoOpen(false)
+                setAboutOpen(!isAboutOpen)
+              }}
               id="info-anchor"
               ref={infoRefElement}
             >


### PR DESCRIPTION
## Why is this pull request needed?

Avoid both popovers being open at once, causing one to cover the other

## What does this pull request change?

Automatically closes the other popover when one of the popover opening buttons are clicked

## Issues related to this change: