### PR TITLE
Feat/component order

### DIFF
--- a/web/src/components/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/components/feature/calculation_input/CalculationInput.tsx
@@ -7,7 +7,7 @@ import { MultiflashResponse } from '../../../api/generated'
 import { AxiosError, AxiosResponse } from 'axios'
 import MercuryAPI from '../../../api/MercuryAPI'
 import { FeedFlowInput } from './FeedFlowInput'
-import { TComponentProperties, TPackage, TResults } from '../../../types'
+import { TComponentProperty, TPackage, TResults } from '../../../types'
 import useLocalStorage from '../../../hooks/useLocalStorage'
 import { TempOrPressureInput } from './TempOrPressureInput'
 
@@ -36,7 +36,7 @@ export const CalculationInput = ({
 }: {
   mercuryApi: MercuryAPI
   setResult: (result: TResults | undefined) => void
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperty[]
 }) => {
   const [isNewOpen, setIsNewOpen] = useState<boolean>(false)
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false)

--- a/web/src/components/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/components/feature/package_dialog/ComponentSelector.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import { ComponentTable } from './ComponentTable'
 import { preSelectedComponents } from '../../../constants'
-import { TComponentProperties, TComponentRatios } from '../../../types'
+import { TComponentProperty, TComponentRatios } from '../../../types'
 import { ComponentTableSum } from './ComponentTableSum'
 
 const ComponentSelectorContainer = styled.div`
@@ -20,7 +20,7 @@ export const ComponentSelector = ({
   ratiosAreValid,
   setRatiosAreValid,
 }: {
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperty[]
   componentRatios: TComponentRatios
   setComponentRatios: (componentInput: TComponentRatios) => void
   ratiosAreValid: { [id: string]: boolean }
@@ -32,7 +32,7 @@ export const ComponentSelector = ({
         preSelectedComponents.includes(option.id)
       )
   const [selectedComponents, setSelectedComponents] =
-    useState<TComponentProperties>(initials)
+    useState<TComponentProperty[]>(initials)
   return (
     <ComponentSelectorContainer>
       <Autocomplete

--- a/web/src/components/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/components/feature/package_dialog/ComponentTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { EdsProvider, Input, Table } from '@equinor/eds-core-react'
-import { TComponentRatios, TComponentProperties } from '../../../types'
+import { TComponentRatios, TComponentProperty } from '../../../types'
 
 const ComponentTableContainer = styled.div`
   display: flex;
@@ -18,7 +18,7 @@ export const ComponentTable = ({
   ratiosAreValid,
   setRatiosAreValid,
 }: {
-  selectedComponents: TComponentProperties
+  selectedComponents: TComponentProperty[]
   componentRatios: TComponentRatios
   setComponentRatios: (componentInput: TComponentRatios) => void
   ratiosAreValid: { [id: string]: boolean }

--- a/web/src/components/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/components/feature/package_dialog/FluidDialog.tsx
@@ -9,11 +9,7 @@ import {
 import { tokens } from '@equinor/eds-tokens'
 import { ComponentSelector } from './ComponentSelector'
 import { useState } from 'react'
-import {
-  TPackage,
-  TComponentProperties,
-  TComponentRatios,
-} from '../../../types'
+import { TPackage, TComponentProperty, TComponentRatios } from '../../../types'
 import { demoFeedComponentRatios } from '../../../constants'
 import { SaveButton } from './SaveButton'
 
@@ -58,7 +54,7 @@ export const FluidDialog = ({
   packages,
 }: {
   close: () => void
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperty[]
   editablePackage?: TPackage
   savePackage: (x?: TPackage) => void
   packages: TPackage[]

--- a/web/src/components/feature/package_dialog/SaveButton.tsx
+++ b/web/src/components/feature/package_dialog/SaveButton.tsx
@@ -1,12 +1,8 @@
 import { Button } from '@equinor/eds-core-react'
-import {
-  TComponentProperties,
-  TComponentRatios,
-  TPackage,
-} from '../../../types'
+import { TComponentProperty, TComponentRatios, TPackage } from '../../../types'
 
 function computeFeedMolecularWeight(
-  componentProperties: TComponentProperties,
+  componentProperties: TComponentProperty[],
   componentRatios: TComponentRatios
 ): number {
   return Object.keys(componentRatios).length !== 0
@@ -21,7 +17,7 @@ function computeFeedMolecularWeight(
 }
 
 export const SaveButton = (props: {
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperty[]
   packageName: string
   packageDescription: string
   componentRatios: TComponentRatios

--- a/web/src/components/feature/results/MoleTable.tsx
+++ b/web/src/components/feature/results/MoleTable.tsx
@@ -1,6 +1,6 @@
 import { DynamicTable } from '../../common/DynamicTable'
 import { formatNumber } from '../../../tableUtils'
-import { TComponentProperties, TResults } from '../../../types'
+import { TComponentProperty, TResults } from '../../../types'
 import { useState } from 'react'
 import { Switch } from '@equinor/eds-core-react'
 import styled from 'styled-components'
@@ -11,7 +11,7 @@ const MoleTableWrapper = styled.div`
 
 function getRows(
   results: TResults,
-  componentProperties: TComponentProperties,
+  componentProperties: TComponentProperty[],
   fullPrecision: boolean
 ): string[][] {
   return Object.entries(results.componentFractions).map(
@@ -31,7 +31,7 @@ function getRows(
 // TODO: Get type from generated API
 export const MoleTable = (props: {
   results: TResults
-  componentProperties: TComponentProperties
+  componentProperties: TComponentProperty[]
 }) => {
   const [fullPrecision, setFullPrecision] = useState<boolean>(false)
   return (

--- a/web/src/components/feature/results/MoleTable.tsx
+++ b/web/src/components/feature/results/MoleTable.tsx
@@ -14,18 +14,18 @@ function getRows(
   componentProperties: TComponentProperty[],
   fullPrecision: boolean
 ): string[][] {
-  return Object.entries(results.componentFractions).map(
-    ([compId, fractions]) => [
-      componentProperties.find((x) => x.id === compId)?.altName ?? '',
+  return componentProperties
+    .filter((x) => x.id in results.componentFractions)
+    .map((x) => [
+      x.altName,
       fullPrecision
-        ? results.feedFractions[compId].toString()
-        : formatNumber(results.feedFractions[compId]),
-      ...fractions.map((x) => {
+        ? results.feedFractions[x.id].toString()
+        : formatNumber(results.feedFractions[x.id]),
+      ...results.componentFractions[x.id].map((x) => {
         if (fullPrecision) return x.toString()
         return formatNumber(x, 2, 3)
       }),
-    ]
-  )
+    ])
 }
 
 // TODO: Get type from generated API

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -30,6 +30,14 @@ export const preSelectedComponents: Array<string> = [
   '605',
 ]
 
+export const orderedComponents: Array<string> = [
+  '5', // Mercury
+  '4', // H2S
+  '3', // Water
+  '6', // MEG
+  '31', // TEG
+]
+
 export const demoFeedComponentRatios = {
   '3': '0.062202',
   '2': '0.0047',

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -9,7 +9,7 @@ import { AxiosResponse } from 'axios'
 import { ComponentResponse } from '../api/generated'
 import { PhaseTable } from '../components/feature/results/PhaseTable'
 import { MercuryWarning } from '../components/feature/results/MercuryWarning'
-import { TComponentProperties, TResults } from '../types'
+import { TComponentProperty, TResults } from '../types'
 
 const Results = styled.div`
   display: flex;
@@ -35,7 +35,7 @@ const DividerWithLargeSpacings = styled(Divider)`
 export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const { mercuryApi } = props
   const [componentProperties, setComponentProperties] =
-    useState<TComponentProperties>()
+    useState<TComponentProperty[]>()
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [result, setResult] = useState<TResults>()
 

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -6,10 +6,11 @@ import { MoleTable } from '../components/feature/results/MoleTable'
 import { CalculationInput } from '../components/feature/calculation_input/CalculationInput'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
-import { ComponentResponse } from '../api/generated'
+import { ComponentProperties, ComponentResponse } from '../api/generated'
 import { PhaseTable } from '../components/feature/results/PhaseTable'
 import { MercuryWarning } from '../components/feature/results/MercuryWarning'
 import { TComponentProperty, TResults } from '../types'
+import { orderedComponents } from '../constants'
 
 const Results = styled.div`
   display: flex;
@@ -32,6 +33,15 @@ const DividerWithLargeSpacings = styled(Divider)`
   margin-top: 40px;
 `
 
+const toSortedArray = (components: { [key: string]: ComponentProperties }) => {
+  const remainingComponents = Object.keys(components).filter(
+    (id) => !orderedComponents.includes(id)
+  )
+  return [...orderedComponents, ...remainingComponents]
+    .filter((id) => components[id])
+    .map((id) => ({ id: id, ...components[id] }))
+}
+
 export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const { mercuryApi } = props
   const [componentProperties, setComponentProperties] =
@@ -44,12 +54,7 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
     mercuryApi
       .getComponents()
       .then((response: AxiosResponse<ComponentResponse>) =>
-        setComponentProperties(
-          Object.entries(response.data.components).map(([id, data]) => ({
-            id: id,
-            ...data,
-          }))
-        )
+        setComponentProperties(toSortedArray(response.data.components))
       )
       .finally(() => setIsLoading(false))
   }, [mercuryApi])

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -3,7 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
-import { TComponentProperties, TResults } from './types'
+import { TComponentProperty, TResults } from './types'
 
 export const mockComponentRatios = {
   '3': 0.062202,
@@ -74,7 +74,7 @@ export const mockResults: TResults = {
   cubicFeedFlow: 1000,
 }
 
-export const mockComponentProperties: TComponentProperties = [
+export const mockComponentProperties: TComponentProperty[] = [
   {
     id: '1',
     chemicalFormula: 'CO2',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,8 +1,8 @@
 import { ComponentProperties, MultiflashResponse } from './api/generated'
 
-export type TComponentProperties = (ComponentProperties & {
+export type TComponentProperty = ComponentProperties & {
   id: string
-})[]
+}
 export type TResults = MultiflashResponse & {
   cubicFeedFlow: number
 }


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because Eleni wants components to be ordered as [Mercury, H2S, Water, Meg, Teg, ..rest]

## What does this pull request change?

- Change TComponentProperties to TComponentProperty[] (necessary to get typing easily)
- Add sorting upon getting the components from the API
- Change how mole table gets its rows to ensure correct order there as well

## Issues related to this change:

Closes #191