### PR TITLE
refactor: remove API prefix

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -16,10 +16,6 @@ from features.metrics import metrics_feature
 from features.multiflash import multiflash_feature
 from features.whoami import whoami_feature
 
-server_root = "/api"
-version = "v1"
-prefix = f"{server_root}/{version}"
-
 
 def create_app() -> FastAPI:
     public_routes = APIRouter()
@@ -31,8 +27,8 @@ def create_app() -> FastAPI:
     authenticated_routes.include_router(multiflash_feature.router)
     authenticated_routes.include_router(component_feature.router)
     app = FastAPI(title="Mercury", description="")
-    app.include_router(authenticated_routes, prefix=prefix, dependencies=[Security(auth_with_jwt)])
-    app.include_router(public_routes, prefix=prefix)
+    app.include_router(authenticated_routes, dependencies=[Security(auth_with_jwt)])
+    app.include_router(public_routes)
 
     @app.middleware("http")
     async def add_process_time_header(request: Request, call_next: Callable) -> Response:

--- a/api/src/tests/integration/features/component/test_component_feature.py
+++ b/api/src/tests/integration/features/component/test_component_feature.py
@@ -5,7 +5,7 @@ from entities.ComponentResponse import ComponentProperties
 
 
 def test_components_feature(test_app):
-    response = test_app.get("/api/v1/components")
+    response = test_app.get("/components")
     results = response.json()
     components = results["components"]
     # using sets as sets do not care about ordering

--- a/api/src/tests/integration/features/health_check/test_health_check_feature.py
+++ b/api/src/tests/integration/features/health_check/test_health_check_feature.py
@@ -3,6 +3,6 @@ from starlette.status import HTTP_200_OK
 
 class TestTodo:
     def test_get(self, test_app):
-        response = test_app.get("/api/v1/health-check")
+        response = test_app.get("/health-check")
         assert response.status_code == HTTP_200_OK
         assert response.content == b"OK"

--- a/api/src/tests/integration/features/multiflash/test_multiflash_feature.py
+++ b/api/src/tests/integration/features/multiflash/test_multiflash_feature.py
@@ -13,7 +13,7 @@ from test_data.multiflash_data import MultiflashInput, MultiflashOutput
     ],
 )
 def test_compute_multiflash_feature(test_app, multiflash_input: dict, multiflash_expected_output: dict):
-    response = test_app.post("/api/v1/multiflash", json=multiflash_input)
+    response = test_app.post("/multiflash", json=multiflash_input)
     results = response.json()
     computed_phase_values = results["phaseValues"]
     computed_component_fractions = results["componentFractions"]

--- a/api/src/tests/integration/features/whoami/test_whoami_feature.py
+++ b/api/src/tests/integration/features/whoami/test_whoami_feature.py
@@ -14,7 +14,7 @@ class TestWhoami:
         config.TEST_TOKEN = True
         user = User(user_id=1, username="foo", roles=["a"])
         headers = {"Authorization": f"Bearer {generate_mock_token(user)}"}
-        response = test_app.get("/api/v1/whoami", headers=headers)
+        response = test_app.get("/whoami", headers=headers)
         data = response.json()
         assert response.status_code == HTTP_200_OK
         assert data["roles"][0] == "a"

--- a/nginx/sites-available/default.conf
+++ b/nginx/sites-available/default.conf
@@ -18,7 +18,7 @@ server {
     gzip_types              text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
     
     location /api/ {
-        proxy_pass          http://api:5000/api/;
+        proxy_pass          http://api:5000/;
 
         include             /etc/nginx/config/general.conf;
         include             /etc/nginx/config/proxy.conf;

--- a/web/src/api/MercuryAPI.tsx
+++ b/web/src/api/MercuryAPI.tsx
@@ -4,7 +4,7 @@ export class MercuryAPI extends MercuryApi {
   constructor(token?: string) {
     const configuration = new Configuration({
       accessToken: token,
-      basePath: `${window.location.protocol}//${window.location.hostname}/`,
+      basePath: `${window.location.protocol}//${window.location.hostname}/api`,
     })
     super(configuration)
   }

--- a/web/src/api/generated/.openapi-generator/FILES
+++ b/web/src/api/generated/.openapi-generator/FILES
@@ -4,6 +4,7 @@ api.ts
 api/component-api.ts
 api/health-check-api.ts
 api/mercury-api.ts
+api/metrics-api.ts
 api/multiflash-api.ts
 api/whoami-api.ts
 base.ts

--- a/web/src/api/generated/api.ts
+++ b/web/src/api/generated/api.ts
@@ -17,6 +17,7 @@
 export * from './api/component-api';
 export * from './api/health-check-api';
 export * from './api/mercury-api';
+export * from './api/metrics-api';
 export * from './api/multiflash-api';
 export * from './api/whoami-api';
 

--- a/web/src/api/generated/api/component-api.ts
+++ b/web/src/api/generated/api/component-api.ts
@@ -35,7 +35,7 @@ export const ComponentApiAxiosParamCreator = function (configuration?: Configura
          * @throws {RequiredError}
          */
         getComponents: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/api/v1/components`;
+            const localVarPath = `/components`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/web/src/api/generated/api/mercury-api.ts
+++ b/web/src/api/generated/api/mercury-api.ts
@@ -44,7 +44,7 @@ export const MercuryApiAxiosParamCreator = function (configuration?: Configurati
         computeMultiflash: async (multiflash: Multiflash, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'multiflash' is not null or undefined
             assertParamExists('computeMultiflash', 'multiflash', multiflash)
-            const localVarPath = `/api/v1/multiflash`;
+            const localVarPath = `/multiflash`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -81,7 +81,7 @@ export const MercuryApiAxiosParamCreator = function (configuration?: Configurati
          * @throws {RequiredError}
          */
         getComponents: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/api/v1/components`;
+            const localVarPath = `/components`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -115,7 +115,7 @@ export const MercuryApiAxiosParamCreator = function (configuration?: Configurati
          * @throws {RequiredError}
          */
         whoami: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/api/v1/whoami/`;
+            const localVarPath = `/whoami/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/web/src/api/generated/api/metrics-api.ts
+++ b/web/src/api/generated/api/metrics-api.ts
@@ -21,19 +21,19 @@ import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObj
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../base';
 /**
- * HealthCheckApi - axios parameter creator
+ * MetricsApi - axios parameter creator
  * @export
  */
-export const HealthCheckApiAxiosParamCreator = function (configuration?: Configuration) {
+export const MetricsApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
          * 
-         * @summary Get
+         * @summary Collect application metrics
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getHealthCheckGet: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/health-check`;
+        getMetricsGet: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/metrics`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -60,59 +60,59 @@ export const HealthCheckApiAxiosParamCreator = function (configuration?: Configu
 };
 
 /**
- * HealthCheckApi - functional programming interface
+ * MetricsApi - functional programming interface
  * @export
  */
-export const HealthCheckApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = HealthCheckApiAxiosParamCreator(configuration)
+export const MetricsApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = MetricsApiAxiosParamCreator(configuration)
     return {
         /**
          * 
-         * @summary Get
+         * @summary Collect application metrics
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getHealthCheckGet(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getHealthCheckGet(options);
+        async getMetricsGet(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMetricsGet(options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
 };
 
 /**
- * HealthCheckApi - factory interface
+ * MetricsApi - factory interface
  * @export
  */
-export const HealthCheckApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = HealthCheckApiFp(configuration)
+export const MetricsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = MetricsApiFp(configuration)
     return {
         /**
          * 
-         * @summary Get
+         * @summary Collect application metrics
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getHealthCheckGet(options?: any): AxiosPromise<string> {
-            return localVarFp.getHealthCheckGet(options).then((request) => request(axios, basePath));
+        getMetricsGet(options?: any): AxiosPromise<string> {
+            return localVarFp.getMetricsGet(options).then((request) => request(axios, basePath));
         },
     };
 };
 
 /**
- * HealthCheckApi - object-oriented interface
+ * MetricsApi - object-oriented interface
  * @export
- * @class HealthCheckApi
+ * @class MetricsApi
  * @extends {BaseAPI}
  */
-export class HealthCheckApi extends BaseAPI {
+export class MetricsApi extends BaseAPI {
     /**
      * 
-     * @summary Get
+     * @summary Collect application metrics
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof HealthCheckApi
+     * @memberof MetricsApi
      */
-    public getHealthCheckGet(options?: any) {
-        return HealthCheckApiFp(this.configuration).getHealthCheckGet(options).then((request) => request(this.axios, this.basePath));
+    public getMetricsGet(options?: any) {
+        return MetricsApiFp(this.configuration).getMetricsGet(options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/web/src/api/generated/api/multiflash-api.ts
+++ b/web/src/api/generated/api/multiflash-api.ts
@@ -42,7 +42,7 @@ export const MultiflashApiAxiosParamCreator = function (configuration?: Configur
         computeMultiflash: async (multiflash: Multiflash, options: any = {}): Promise<RequestArgs> => {
             // verify required parameter 'multiflash' is not null or undefined
             assertParamExists('computeMultiflash', 'multiflash', multiflash)
-            const localVarPath = `/api/v1/multiflash`;
+            const localVarPath = `/multiflash`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/web/src/api/generated/api/whoami-api.ts
+++ b/web/src/api/generated/api/whoami-api.ts
@@ -33,7 +33,7 @@ export const WhoamiApiAxiosParamCreator = function (configuration?: Configuratio
          * @throws {RequiredError}
          */
         whoami: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/api/v1/whoami/`;
+            const localVarPath = `/whoami/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/web/src/api/generated/models/multiflash-response.ts
+++ b/web/src/api/generated/models/multiflash-response.ts
@@ -33,7 +33,7 @@ export interface MultiflashResponse {
      */
     componentFractions: { [key: string]: Array<number>; };
     /**
-     * 
+     * Ratio of components in the feed (guaranteed to sum to 1)
      * @type {{ [key: string]: number; }}
      * @memberof MultiflashResponse
      */


### PR DESCRIPTION
## Why is this pull request needed?

- We are not using a versioned API strategy
- radix expects metrics to be served from "/metrics"

## What does this pull request change?

- Remove prefix for API
- Regenerate TS-Client
- Update paths in python unit tests

## Issues related to this change:
closes #238