### PR TITLE
refactor: Remove setAreRatioValid

### DIFF
--- a/web/src/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/feature/package_dialog/ComponentSelector.tsx
@@ -19,14 +19,6 @@ export const ComponentSelector = ({
             )
           ),
         })
-        dispatch({
-          type: 'setIsRatioValid',
-          value: Object.fromEntries(
-            Object.entries(state.isRatioValid).filter(([compId]) =>
-              selectedItems.find((x) => x.id === compId)
-            )
-          ),
-        })
         dispatch({ type: 'setSelectedComponents', value: selectedItems })
       }}
       label="Add components"

--- a/web/src/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/feature/package_dialog/ComponentTable.tsx
@@ -18,9 +18,6 @@ export const ComponentTable = (): JSX.Element => {
     id: string
   ) {
     const ratio = event.target.value
-    const newIsRatioValid = { ...state.isRatioValid }
-    newIsRatioValid[id] = event.target.checkValidity() && !isNaN(Number(ratio))
-    dispatch({ type: 'setIsRatioValid', value: newIsRatioValid })
     const newRatios = { ...state.ratios }
     if (ratio === '') {
       delete newRatios[id]
@@ -40,7 +37,6 @@ export const ComponentTable = (): JSX.Element => {
           <Input
             id={`${component.chemicalFormula}-input`}
             value={state.ratios[component.id] ?? ''}
-            pattern="^\d+(\.\d+)?([eE][-+]?\d+)?$"
             variant={
               state.isRatioValid[component.id] === false ||
               (component.id === '5' && !(Number(state.ratios['5']) > 0))

--- a/web/src/feature/package_dialog/context/PackageDialogContext.tsx
+++ b/web/src/feature/package_dialog/context/PackageDialogContext.tsx
@@ -10,7 +10,6 @@ export type Action =
   | { type: 'setName'; value: string }
   | { type: 'setDescription'; value: string }
   | { type: 'setRatios'; value: TComponentRatios }
-  | { type: 'setIsRatioValid'; value: { [id: string]: boolean } }
   | { type: 'setSelectedComponents'; value: TComponentProperty[] }
 
 const PackageDialogContext = createContext<{

--- a/web/src/feature/package_dialog/context/reducer.tsx
+++ b/web/src/feature/package_dialog/context/reducer.tsx
@@ -16,15 +16,17 @@ export function packageDialogReducer(state: TPackageDialog, action: Action) {
       }
     }
     case 'setRatios': {
+      const regex = /^\d+(\.\d+)?([eE][-+]?\d+)?$/
+      const valids = Object.fromEntries(
+        Object.entries(action.value).map(([key, ratio]) => [
+          key,
+          regex.test(ratio) && !isNaN(Number(ratio)),
+        ])
+      )
       return {
         ...state,
         ratios: action.value,
-      }
-    }
-    case 'setIsRatioValid': {
-      return {
-        ...state,
-        isRatioValid: action.value,
+        isRatioValid: valids,
       }
     }
     case 'setSelectedComponents': {


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Removes the logic of validating ratios into the reducer

## Issues related to this change: