### PR TITLE
fix: Fix tag logging

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
 
       - name: "Build and Publish Web"
         shell: bash
@@ -82,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
 
       - name: "Build and Publish API"
         shell: bash


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because when fetch depth is not set, it is default 1. That one commit is then tagged as grafted, which messes up the version text we're showing on the website

## What does this pull request change?

Increase fetch-depth to 2 to remove the grafted tag from the relevant commit

## Issues related to this change:

Closes #247