### PR TITLE
fix: increase timeout for long computations

### DIFF
--- a/api/src/init.sh
+++ b/api/src/init.sh
@@ -5,7 +5,7 @@ cat version.txt
 
 if [ "$1" = 'api' ]; then
   if [ "${ENVIRONMENT:-'local'}" != "local" ]; then
-    gunicorn app:create_app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+    gunicorn app:create_app --timeout 60 --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
   else
     python3 /code/app.py run
   fi


### PR DESCRIPTION
## Why is this pull request needed?
Long running computations (~40-50 seconds) were killed by gunicorn due to it believing they were stalled.

## What does this pull request change?
After looking at several solutions, ended up with the simplest one: Increasing the timeout.

## Issues related to this change:
Closes #184