### PR TITLE
fix: Keep comp input order by using array

### DIFF
--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -17,9 +17,9 @@ export const molePerStandardCubicMeter = 42.29256
 
 export const preSelectedComponents: Array<string> = [
   '5',
+  '3',
   '1',
   '2',
-  '3',
   '101',
   '201',
   '301',
@@ -38,20 +38,20 @@ export const orderedComponents: Array<string> = [
   '31', // TEG
 ]
 
-export const demoFeedComponentRatios = {
-  '3': '0.062202',
-  '2': '0.0047',
-  '1': '0.046539',
-  '101': '0.65364',
-  '201': '0.086307',
-  '301': '0.045563',
-  '401': '0.007579',
-  '402': '0.015481',
-  '503': '0.005188',
-  '504': '0.00612',
-  '605': '0.066681',
-  '5': '0.001',
-}
+export const demoFeedComponentRatios = [
+  { id: '3', ratio: '0.062202' },
+  { id: '2', ratio: '0.0047' },
+  { id: '1', ratio: '0.046539' },
+  { id: '101', ratio: '0.65364' },
+  { id: '201', ratio: '0.086307' },
+  { id: '301', ratio: '0.045563' },
+  { id: '401', ratio: '0.007579' },
+  { id: '402', ratio: '0.015481' },
+  { id: '503', ratio: '0.005188' },
+  { id: '504', ratio: '0.00612' },
+  { id: '605', ratio: '0.066681' },
+  { id: '5', ratio: '0.001' },
+]
 
 export const demoComponentInput = {
   '3': {

--- a/web/src/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/feature/calculation_input/CalculationInput.tsx
@@ -74,9 +74,7 @@ export const CalculationInput = ({
           .computeMultiflash({
             multiflash: {
               componentComposition: Object.fromEntries(
-                Object.entries(selectedPackage.components).map(
-                  ([id, ratio]) => [id, Number(ratio)]
-                )
+                selectedPackage.components.map((x) => [x.id, Number(x.ratio)])
               ),
               temperature: temperature,
               pressure: pressure,

--- a/web/src/feature/package_dialog/ComponentSelector.tsx
+++ b/web/src/feature/package_dialog/ComponentSelector.tsx
@@ -1,29 +1,16 @@
 import { Autocomplete } from '@equinor/eds-core-react'
-import { TComponentProperty } from '../../types'
 import { usePackageDialogContext } from './context/PackageDialogContext'
 
-export const ComponentSelector = ({
-  componentProperties,
-}: {
-  componentProperties: TComponentProperty[]
-}) => {
+export const ComponentSelector = () => {
   const { state, dispatch } = usePackageDialogContext()
   return (
     <Autocomplete
       onOptionsChange={({ selectedItems }) => {
-        dispatch({
-          type: 'setRatios',
-          value: Object.fromEntries(
-            Object.entries(state.ratios).filter(([compId]) =>
-              selectedItems.find((x) => x.id === compId)
-            )
-          ),
-        })
         dispatch({ type: 'setSelectedComponents', value: selectedItems })
       }}
       label="Add components"
       multiple
-      options={componentProperties}
+      options={state.componentProperties}
       selectedOptions={state.selectedComponents}
       optionLabel={(option) => `${option.altName} (${option.chemicalFormula})`}
     />

--- a/web/src/feature/package_dialog/ComponentTable.tsx
+++ b/web/src/feature/package_dialog/ComponentTable.tsx
@@ -18,12 +18,9 @@ export const ComponentTable = (): JSX.Element => {
     id: string
   ) {
     const ratio = event.target.value
-    const newRatios = { ...state.ratios }
-    if (ratio === '') {
-      delete newRatios[id]
-    } else {
-      newRatios[id] = ratio
-    }
+    const newRatios = state.ratios.map((x) =>
+      x.id === id ? { id: id, ratio: ratio } : x
+    )
     dispatch({ type: 'setRatios', value: newRatios })
   }
 
@@ -36,10 +33,11 @@ export const ComponentTable = (): JSX.Element => {
         <Table.Cell data-testid={`Ratio (mol)-${rowIndex}`}>
           <Input
             id={`${component.chemicalFormula}-input`}
-            value={state.ratios[component.id] ?? ''}
+            value={state.ratios.find((x) => x.id === component.id)?.ratio ?? ''}
             variant={
               state.isRatioValid[component.id] === false ||
-              (component.id === '5' && !(Number(state.ratios['5']) > 0))
+              (component.id === '5' &&
+                !(Number(state.ratios.find((x) => x.id === '5')?.ratio) > 0))
                 ? 'error'
                 : undefined
             }

--- a/web/src/feature/package_dialog/ComponentTableSum.tsx
+++ b/web/src/feature/package_dialog/ComponentTableSum.tsx
@@ -1,10 +1,10 @@
 import { EdsProvider, Table } from '@equinor/eds-core-react'
-import { TComponentRatios } from '../../types'
+import { TComponentRatio } from '../../types'
 import { formatNumber } from '../../tableUtils'
 import { usePackageDialogContext } from './context/PackageDialogContext'
 
-function computeComponentRatioSum(componentRatios: TComponentRatios) {
-  const sum = Object.values(componentRatios).reduce((a, b) => a + Number(b), 0)
+function computeComponentRatioSum(componentRatios: TComponentRatio[]) {
+  const sum = componentRatios.reduce((a, b) => a + Number(b.ratio), 0)
   if (isNaN(sum)) {
     return ''
   }

--- a/web/src/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/feature/package_dialog/FluidDialog.tsx
@@ -66,26 +66,20 @@ export const FluidDialog = ({
   savePackage: (x?: TPackage) => void
   packages: TPackage[]
 }) => {
-  const initial: TPackageDialog =
-    editablePackage === undefined
-      ? {
-          name: '',
-          description: '',
-          ratios: {},
-          isRatioValid: {},
-          selectedComponents: componentProperties.filter((option) =>
-            preSelectedComponents.includes(option.id)
-          ),
-        }
-      : {
-          name: editablePackage.name,
-          description: editablePackage.description,
-          ratios: editablePackage.components,
-          isRatioValid: {},
-          selectedComponents: componentProperties.filter(
-            (option) => editablePackage.components[option.id]
-          ),
-        }
+  const initial: TPackageDialog = {
+    name: editablePackage?.name ?? '',
+    description: editablePackage?.description ?? '',
+    ratios:
+      editablePackage?.components ??
+      preSelectedComponents.map((x) => ({ id: x, ratio: '' })),
+    isRatioValid: {},
+    selectedComponents: (
+      editablePackage?.components.map((x) => x.id) ?? preSelectedComponents
+    )
+      .map((x) => componentProperties.find((prop) => prop.id === x))
+      .filter((x): x is TComponentProperty => !!x),
+    componentProperties: componentProperties,
+  }
 
   return (
     <PackageDialogProvider initial={initial}>
@@ -103,13 +97,10 @@ export const FluidDialog = ({
             <FirstColumn>
               <NameField />
               <DescriptionField />
-              <TemplateSelector
-                packages={packages}
-                componentProperties={componentProperties}
-              />
+              <TemplateSelector packages={packages} />
             </FirstColumn>
             <SecondColumn>
-              <ComponentSelector componentProperties={componentProperties} />
+              <ComponentSelector />
               <ComponentTable />
               <ComponentTableSum />
             </SecondColumn>
@@ -120,7 +111,6 @@ export const FluidDialog = ({
                 Cancel
               </Button>
               <SaveButton
-                componentProperties={componentProperties}
                 editablePackage={editablePackage}
                 savePackage={savePackage}
               />

--- a/web/src/feature/package_dialog/SaveButton.tsx
+++ b/web/src/feature/package_dialog/SaveButton.tsx
@@ -1,24 +1,24 @@
 import { Button } from '@equinor/eds-core-react'
-import { TComponentProperty, TComponentRatios, TPackage } from '../../types'
+import { TComponentProperty, TComponentRatio, TPackage } from '../../types'
 import { usePackageDialogContext } from './context/PackageDialogContext'
 
 function computeFeedMolecularWeight(
   componentProperties: TComponentProperty[],
-  componentRatios: TComponentRatios
+  componentRatios: TComponentRatio[]
 ): number {
-  return Object.keys(componentRatios).length !== 0
-    ? Object.entries(componentRatios)
+  return componentRatios.length !== 0
+    ? componentRatios
         .map(
-          ([id, ratio]) =>
-            Number(ratio) *
-            (componentProperties.find((x) => x.id === id)?.molecularWeight ?? 0)
+          (ratio) =>
+            Number(ratio.ratio) *
+            (componentProperties.find((prop) => prop.id === ratio.id)
+              ?.molecularWeight ?? 0)
         )
         .reduce((a, b) => a + b)
     : 1
 }
 
 export const SaveButton = (props: {
-  componentProperties: TComponentProperty[]
   editablePackage?: TPackage
   savePackage: (x?: TPackage) => void
 }) => {
@@ -27,14 +27,13 @@ export const SaveButton = (props: {
     const isValidPackage =
       state.name.length > 0 &&
       Object.values(state.isRatioValid).every((x) => x) &&
-      Object.values(state.ratios).some((x) => Number(x) > 0) &&
-      Number(state.ratios['5']) > 0
+      Number(state.ratios.find((x) => x.id === '5')?.ratio) > 0
     if (props.editablePackage) {
       const ratioHasChanged =
-        Object.keys(props.editablePackage.components).length !==
-          Object.keys(state.ratios).length ||
-        !Object.entries(props.editablePackage.components).every(
-          ([compId, ratio]) => ratio === state.ratios[compId]
+        props.editablePackage.components.length !== state.ratios.length ||
+        !props.editablePackage.components.every(
+          (old) =>
+            old.ratio === state.ratios.find((x) => x.id === old.id)?.ratio
         )
       const hasChanged =
         state.name !== props.editablePackage.name ||
@@ -53,7 +52,7 @@ export const SaveButton = (props: {
           description: state.description,
           components: state.ratios,
           molecularWeightSum: computeFeedMolecularWeight(
-            props.componentProperties,
+            state.componentProperties,
             state.ratios
           ),
         })

--- a/web/src/feature/package_dialog/TemplateSelector.tsx
+++ b/web/src/feature/package_dialog/TemplateSelector.tsx
@@ -1,12 +1,9 @@
 import { Autocomplete } from '@equinor/eds-core-react'
 import { preSelectedComponents } from '../../constants'
-import { TComponentProperty, TPackage } from '../../types'
+import { TPackage } from '../../types'
 import { usePackageDialogContext } from './context/PackageDialogContext'
 
-export const TemplateSelector = (props: {
-  packages: TPackage[]
-  componentProperties: TComponentProperty[]
-}) => {
+export const TemplateSelector = (props: { packages: TPackage[] }) => {
   const { dispatch } = usePackageDialogContext()
   return (
     <Autocomplete
@@ -15,14 +12,11 @@ export const TemplateSelector = (props: {
       optionLabel={(option) => option.name}
       onOptionsChange={(changes) => {
         const template = changes.selectedItems[0]
-        dispatch({ type: 'setRatios', value: template?.components ?? {} })
         dispatch({
-          type: 'setSelectedComponents',
-          value: template
-            ? props.componentProperties.filter((x) => template.components[x.id])
-            : props.componentProperties.filter((option) =>
-                preSelectedComponents.includes(option.id)
-              ),
+          type: 'setRatios',
+          value:
+            template?.components ??
+            preSelectedComponents.map((x) => ({ id: x, ratio: '' })),
         })
       }}
       autoWidth

--- a/web/src/feature/package_dialog/context/PackageDialogContext.tsx
+++ b/web/src/feature/package_dialog/context/PackageDialogContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useReducer } from 'react'
 import {
   TComponentProperty,
-  TComponentRatios,
+  TComponentRatio,
   TPackageDialog,
 } from '../../../types'
 import { packageDialogReducer } from './reducer'
@@ -9,7 +9,7 @@ import { packageDialogReducer } from './reducer'
 export type Action =
   | { type: 'setName'; value: string }
   | { type: 'setDescription'; value: string }
-  | { type: 'setRatios'; value: TComponentRatios }
+  | { type: 'setRatios'; value: TComponentRatio[] }
   | { type: 'setSelectedComponents'; value: TComponentProperty[] }
 
 const PackageDialogContext = createContext<{

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -6,26 +6,28 @@ export type TComponentProperty = ComponentProperties & {
 export type TResults = MultiflashResponse & {
   cubicFeedFlow: number
 }
-export type TComponentRatios = {
-  [id: string]: string
+export type TComponentRatio = {
+  id: string
+  ratio: string
 }
 export type TFeedUnit = 'kg/d' | 'Sm3/d'
 export type TFeedFlow = { unit: TFeedUnit; value: number }
 export type TPackage = {
   name: string
   description: string
-  components: TComponentRatios
+  components: TComponentRatio[]
   molecularWeightSum: number
 }
 
 export type TPackageDialog = {
   name: string
   description: string
-  ratios: TComponentRatios
+  ratios: TComponentRatio[]
   isRatioValid: {
     [id: string]: boolean
   }
   selectedComponents: TComponentProperty[]
+  componentProperties: TComponentProperty[]
 }
 
 export type TCalcStatus = 'calculating' | 'done' | 'failure' | undefined


### PR DESCRIPTION
## Why is this pull request needed?

Eleni wants the component order to be constant after saving and reopening package

## What does this pull request change?

The fix turned out to be more complicated than I had thought, partly because our stored ratios might not have the same order as the selected components (imagine adding components in one order, and giving them value in another - then the comp order would differ). To fix this, I made the order and length of selectedComponents and ratios equal. I also made the code more robust, by moving logic into the reducer. 

**PLEASE TEST THIS** (I have tested a lot, but I still might have forgotten something)

## Issues related to this change:

Closes #259