### PR TITLE
feature: Make template intuitive

### DIFF
--- a/web/src/feature/package_dialog/FluidDialog.tsx
+++ b/web/src/feature/package_dialog/FluidDialog.tsx
@@ -86,7 +86,7 @@ export const FluidDialog = ({
       <WideDialog open onClose={close} isDismissable>
         <Dialog.Header>
           <Typography
-            variant="h6"
+            variant="h3"
             color={tokens.colors.infographic.primary__moss_green_100.hex}
           >
             {editablePackage === undefined ? 'Create' : 'Edit'} fluid package
@@ -97,7 +97,9 @@ export const FluidDialog = ({
             <FirstColumn>
               <NameField />
               <DescriptionField />
-              <TemplateSelector packages={packages} />
+              {editablePackage === undefined && (
+                <TemplateSelector packages={packages} />
+              )}
             </FirstColumn>
             <SecondColumn>
               <ComponentSelector />

--- a/web/src/feature/package_dialog/SaveButton.tsx
+++ b/web/src/feature/package_dialog/SaveButton.tsx
@@ -59,7 +59,7 @@ export const SaveButton = (props: {
       }}
       disabled={!isSaveable()}
     >
-      Save
+      {props.editablePackage ? 'Update' : 'Create'}
     </Button>
   )
 }

--- a/web/src/feature/package_dialog/TemplateSelector.tsx
+++ b/web/src/feature/package_dialog/TemplateSelector.tsx
@@ -7,7 +7,7 @@ export const TemplateSelector = (props: { packages: TPackage[] }) => {
   const { dispatch } = usePackageDialogContext()
   return (
     <Autocomplete
-      label="Template"
+      label="Use existing fluid as template"
       options={props.packages}
       optionLabel={(option) => option.name}
       onOptionsChange={(changes) => {


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because the template could easily be misunderstood

## What does this pull request change?

- Increase dialog title text size
- Show only template when in new mode
- Rename save button to create/update
- Make template label more informative

## Issues related to this change:

Closes #262