### PR TITLE
fix: Rename co2

### DIFF
--- a/api/src/common/components.py
+++ b/api/src/common/components.py
@@ -1,7 +1,7 @@
 COMPONENTS = {
     "1": {
         "chemical_formula": "CO2",
-        "alt_name": "Carbondioxide",
+        "alt_name": "Carbon Dioxide",
         "molecular_weight": 44.01,
     },
     "2": {

--- a/api/src/entities/ComponentResponse.py
+++ b/api/src/entities/ComponentResponse.py
@@ -35,7 +35,7 @@ class ComponentResponse(BaseModel):
         schema_extra = {
             "example": {
                 "components": {
-                    "1": {"chemicalFormula": "CO2", "altName": "Carbondioxide", "molecularWeight": 44.01},
+                    "1": {"chemicalFormula": "CO2", "altName": "Carbon Dioxide", "molecularWeight": 44.01},
                     "2": {"chemicalFormula": "N2", "altName": "Nitrogen", "molecularWeight": 28.014},
                     "3": {"chemicalFormula": "H2O", "altName": "Water", "molecularWeight": 18.015},
                     "101": {"chemicalFormula": "CH4", "altName": "Methane", "molecularWeight": 16.043},

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -78,7 +78,7 @@ export const mockComponentProperties: TComponentProperty[] = [
   {
     id: '1',
     chemicalFormula: 'CO2',
-    altName: 'Carbondioxide',
+    altName: 'Carbon Dioxide',
     molecularWeight: 44.01,
   },
   {


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because Eleni wants it

## What does this pull request change?

Rename all occurrences of Carbondioxide to Carbon Dioxide

## Issues related to this change:

Closes #293