### PR TITLE
fix: Same codeowners for all code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,3 @@
 
 # Repo owners
 *       @rikkebl @ingeridhellen @mariuswinger @soofstad
-
-# API owners
-/api/   @mariuswinger @soofstad


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because a PR needs the approval of all relevant code owners before we can merge it. Since RIkke and I are not code owners of the API currently, we can't approve dependabot issues for the API.

## What does this pull request change?

Makes all of us codeowners for everything

## Issues related to this change: