### PR TITLE
refactor: Rename tables to match caption

### DIFF
--- a/web/src/feature/results/HgDistributionTable.test.tsx
+++ b/web/src/feature/results/HgDistributionTable.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react'
-import { PhaseTable } from './PhaseTable'
+import { HgDistributionTable } from './HgDistributionTable'
 import '@testing-library/jest-dom/extend-expect'
 import { mockResults } from '../../setupTests'
 
 test('renders without crashing and displaying correct values in table', async () => {
-  render(<PhaseTable results={mockResults} />)
+  render(<HgDistributionTable results={mockResults} />)
   // @ts-ignore because not able to get eslint to discover these types
   expect(screen.getByTestId('0-Vapor-0')).toHaveTextContent('9577 μg/Sm3')
   // @ts-ignore because not able to get eslint to discover these types

--- a/web/src/feature/results/HgDistributionTable.tsx
+++ b/web/src/feature/results/HgDistributionTable.tsx
@@ -34,7 +34,7 @@ function getRows(results: TResults): string[][] {
   ]
 }
 
-export const PhaseTable = (props: { results: TResults }) => {
+export const HgDistributionTable = (props: { results: TResults }) => {
   return (
     <DynamicTable
       subtables={[

--- a/web/src/feature/results/PhaseEquilibriumTable.test.tsx
+++ b/web/src/feature/results/PhaseEquilibriumTable.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { MoleTable } from './MoleTable'
+import { PhaseEquilibriumTable } from './PhaseEquilibriumTable'
 import '@testing-library/jest-dom/extend-expect'
 import { mockComponentProperties, mockResults } from '../../setupTests'
 
 test('renders without crashing and displaying correct values in table', async () => {
   render(
-    <MoleTable
+    <PhaseEquilibriumTable
       componentProperties={mockComponentProperties}
       results={mockResults}
     />

--- a/web/src/feature/results/PhaseEquilibriumTable.tsx
+++ b/web/src/feature/results/PhaseEquilibriumTable.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { Switch } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 
-const MoleTableWrapper = styled.div`
+const Wrapper = styled.div`
   text-align: right;
 `
 
@@ -29,13 +29,13 @@ function getRows(
 }
 
 // TODO: Get type from generated API
-export const MoleTable = (props: {
+export const PhaseEquilibriumTable = (props: {
   results: TResults
   componentProperties: TComponentProperty[]
 }) => {
   const [fullPrecision, setFullPrecision] = useState<boolean>(false)
   return (
-    <MoleTableWrapper>
+    <Wrapper>
       <DynamicTable
         subtables={[
           {
@@ -75,6 +75,6 @@ export const MoleTable = (props: {
         checked={fullPrecision}
         onChange={(event) => setFullPrecision(event.target.checked)}
       />
-    </MoleTableWrapper>
+    </Wrapper>
   )
 }

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -2,12 +2,12 @@ import styled from 'styled-components'
 import { Divider } from '@equinor/eds-core-react'
 import { Header } from '../common/Header'
 import { useEffect, useState } from 'react'
-import { MoleTable } from '../feature/results/MoleTable'
+import { PhaseEquilibriumTable } from '../feature/results/PhaseEquilibriumTable'
 import { CalculationInput } from '../feature/calculation_input/CalculationInput'
 import MercuryAPI from '../api/MercuryAPI'
 import { AxiosResponse } from 'axios'
 import { ComponentProperties, ComponentResponse } from '../api/generated'
-import { PhaseTable } from '../feature/results/PhaseTable'
+import { HgDistributionTable } from '../feature/results/HgDistributionTable'
 import { TCalcStatus, TComponentProperty, TResults } from '../types'
 import { orderedComponents } from '../constants'
 import { Status } from '../feature/Status'
@@ -81,8 +81,8 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
           <Status calcStatus={calcStatus} result={result} />
           {result && (
             <Results>
-              <PhaseTable results={result} />
-              <MoleTable
+              <HgDistributionTable results={result} />
+              <PhaseEquilibriumTable
                 results={result}
                 componentProperties={componentProperties}
               />


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because it's very confusing that the phasetable was not the table with caption "phase equilibrium results"

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change: