### PR TITLE
chore: migrate from radix machine token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,15 +16,32 @@ env:
   RADIX_APP: mercury
   RADIX_USER: mlw@equinor.com
 
+permissions:
+  id-token: write
+
 jobs:
   deploy-on-radix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: 0cd10735-a40c-4ff6-84c8-74e3b54ed93f #app registration Application ID
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: 'Get Azure principal token for Radix'
+        run: |
+          token=$(az account get-access-token --resource 0cd10735-a40c-4ff6-84c8-74e3b54ed93f --query=accessToken -otsv)
+          echo "::add-mask::$token"
+          echo "APP_SERVICE_ACCOUNT_TOKEN=$token" >> $GITHUB_ENV
+
       - name: Deploy on Radix
         uses: equinor/radix-github-actions@master
         env:
-          APP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.APP_SERVICE_ACCOUNT_TOKEN }}
+          APP_SERVICE_ACCOUNT_TOKEN: ${{ env.APP_SERVICE_ACCOUNT_TOKEN }}
         with:
           args: >
             create job

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ web/.yarn/*
 !web/.yarn/releases
 !web/.yarn/sdks
 !web/.yarn/versions
+.idea


### PR DESCRIPTION
## Why is this pull request needed?

Radix is disabling "machine user" support

## What does this pull request change?

Use a Azure Service Principal with federated identity to authenticate with radix

## Issues related to this change:
none