### PR TITLE
Feat/last input context

### DIFF
--- a/web/src/feature/Status.tsx
+++ b/web/src/feature/Status.tsx
@@ -5,11 +5,14 @@ import {
   warning_outlined,
 } from '@equinor/eds-icons'
 import { TCalcStatus, TResults } from '../types'
+import { useLastInputContext } from '../pages/context/LastInputContext'
 
 export const Status = (props: {
   calcStatus: TCalcStatus
   result: TResults | undefined
 }) => {
+  const { lastInput } = useLastInputContext()
+
   switch (props.calcStatus) {
     case 'calculating':
       return <Progress.Linear />
@@ -18,14 +21,13 @@ export const Status = (props: {
         props.result &&
         props.result.phaseValues.find((x) => x.phase === 'Mercury')
       ) {
+        const state = lastInput.temperature < -38.83 ? 'Solid' : 'Liquid'
         return (
           <EdsBanner>
             <EdsBanner.Icon variant="warning">
               <Icon data={warning_outlined} />
             </EdsBanner.Icon>
-            <EdsBanner.Message>
-              Liquid mercury has been formed
-            </EdsBanner.Message>
+            <EdsBanner.Message>{`${state} mercury has been formed`}</EdsBanner.Message>
           </EdsBanner>
         )
       } else {

--- a/web/src/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/feature/calculation_input/CalculationInput.tsx
@@ -113,10 +113,7 @@ export const CalculationInput = ({
             setCalcStatus('done')
           })
           .catch(() => {
-            appInsights.trackEvent(
-              { name: 'CalculationFailed' },
-              requestParameters
-            )
+            appInsights.trackEvent({ name: 'CalculationFailed' }, input)
             setCalcStatus('failure')
           })
           .finally(() => setCalculating(false))

--- a/web/src/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/feature/calculation_input/CalculationInput.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../types'
 import useLocalStorage from '../../hooks/useLocalStorage'
 import { TempOrPressureInput } from './TempOrPressureInput'
+import { useLastInputContext } from '../../pages/context/LastInputContext'
 import { useAppInsightsContext } from '@microsoft/applicationinsights-react-js'
 
 const FlexContainer = styled.div`
@@ -48,6 +49,7 @@ export const CalculationInput = ({
 }) => {
   const [isNewOpen, setIsNewOpen] = useState<boolean>(false)
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false)
+  const { setLastInput } = useLastInputContext()
   const [temperature, setTemperature] = useState<number>(15)
   const [pressure, setPressure] = useState<number>(1)
   const [calculating, setCalculating] = useState<boolean>(false)
@@ -73,17 +75,18 @@ export const CalculationInput = ({
         appInsights.trackEvent({ name: 'CalculationStarted' })
         setResult(undefined)
         setCalcStatus('calculating')
-        const requestParameters = {
-          multiflash: {
-            componentComposition: Object.fromEntries(
-              selectedPackage.components.map((x) => [x.id, Number(x.ratio)])
-            ),
-            temperature: temperature,
-            pressure: pressure,
-          },
+        const input = {
+          componentComposition: Object.fromEntries(
+            selectedPackage.components.map((x) => [x.id, Number(x.ratio)])
+          ),
+          temperature: temperature,
+          pressure: pressure,
         }
+        setLastInput(input)
         mercuryApi
-          .computeMultiflash(requestParameters)
+          .computeMultiflash({
+            multiflash: input,
+          })
           .then((result: AxiosResponse<MultiflashResponse>) => {
             setResult({
               phaseValues: Object.entries(result.data.phaseValues).map(

--- a/web/src/feature/calculation_input/CalculationInput.tsx
+++ b/web/src/feature/calculation_input/CalculationInput.tsx
@@ -81,6 +81,7 @@ export const CalculationInput = ({
           ),
           temperature: temperature,
           pressure: pressure,
+          cubicFeedFlow: cubicFeedFlow,
         }
         setLastInput(input)
         mercuryApi

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -12,6 +12,7 @@ import { TCalcStatus, TComponentProperty, TResults } from '../types'
 import { orderedComponents } from '../constants'
 import { Status } from '../feature/Status'
 import ErrorBoundary from '../common/ErrorBoundary'
+import { LastInputProvider } from './context/LastInputContext'
 
 import { useAppInsightsContext } from '@microsoft/applicationinsights-react-js'
 
@@ -52,12 +53,12 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [calcStatus, setCalcStatus] = useState<TCalcStatus>()
   const [result, setResult] = useState<TResults>()
+
   const appInsights = useAppInsightsContext()
 
   useEffect(() => {
     appInsights.trackEvent({ name: 'MainPageLoaded' }, {})
   }, [])
-
   // Fetch list of components name once on page load
   useEffect(() => {
     mercuryApi
@@ -78,23 +79,25 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
       <Header />
       <Container>
         <ErrorBoundary>
-          <CalculationInput
-            mercuryApi={mercuryApi}
-            setResult={setResult}
-            setCalcStatus={setCalcStatus}
-            componentProperties={componentProperties}
-          />
-          <DividerWithLargeSpacings />
-          <Status calcStatus={calcStatus} result={result} />
-          {result && (
-            <Results>
-              <HgDistributionTable results={result} />
-              <PhaseEquilibriumTable
-                results={result}
-                componentProperties={componentProperties}
-              />
-            </Results>
-          )}
+          <LastInputProvider>
+            <CalculationInput
+              mercuryApi={mercuryApi}
+              setResult={setResult}
+              setCalcStatus={setCalcStatus}
+              componentProperties={componentProperties}
+            />
+            <DividerWithLargeSpacings />
+            <Status calcStatus={calcStatus} result={result} />
+            {result && (
+              <Results>
+                <HgDistributionTable results={result} />
+                <PhaseEquilibriumTable
+                  results={result}
+                  componentProperties={componentProperties}
+                />
+              </Results>
+            )}
+          </LastInputProvider>
         </ErrorBoundary>
       </Container>
     </>

--- a/web/src/pages/Main.tsx
+++ b/web/src/pages/Main.tsx
@@ -90,6 +90,7 @@ export const MainPage = (props: { mercuryApi: MercuryAPI }): JSX.Element => {
             <Status calcStatus={calcStatus} result={result} />
             {result && (
               <Results>
+                {/*TODO: Make use of cubicFeedFlow in LastInputContext here: */}
                 <HgDistributionTable results={result} />
                 <PhaseEquilibriumTable
                   results={result}

--- a/web/src/pages/context/LastInputContext.tsx
+++ b/web/src/pages/context/LastInputContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useState } from 'react'
+import { Multiflash } from '../../api/generated'
+
+const LastInputContext = createContext<
+  | { lastInput: Multiflash; setLastInput: (input: Multiflash) => void }
+  | undefined
+>(undefined)
+
+function LastInputProvider({ children }: { children: React.ReactNode }) {
+  const initial = {
+    componentComposition: {},
+    temperature: 15,
+    pressure: 1,
+  }
+  const [lastInput, setLastInput] = useState<Multiflash>(initial as Multiflash)
+
+  return (
+    <LastInputContext.Provider value={{ lastInput, setLastInput }}>
+      {children}
+    </LastInputContext.Provider>
+  )
+}
+
+function useLastInputContext() {
+  const context = useContext(LastInputContext)
+  if (context === undefined) {
+    throw new Error(
+      'useLastInputContext must be used within a LastInputProvider'
+    )
+  }
+  return context
+}
+
+export { useLastInputContext, LastInputProvider, LastInputContext }

--- a/web/src/pages/context/LastInputContext.tsx
+++ b/web/src/pages/context/LastInputContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext, useState } from 'react'
 import { Multiflash } from '../../api/generated'
+import { TLastInput } from '../../types'
 
 const LastInputContext = createContext<
-  | { lastInput: Multiflash; setLastInput: (input: Multiflash) => void }
+  | { lastInput: Multiflash; setLastInput: (input: TLastInput) => void }
   | undefined
 >(undefined)
 
@@ -11,8 +12,9 @@ function LastInputProvider({ children }: { children: React.ReactNode }) {
     componentComposition: {},
     temperature: 15,
     pressure: 1,
+    cubicFeedFlow: 1000,
   }
-  const [lastInput, setLastInput] = useState<Multiflash>(initial as Multiflash)
+  const [lastInput, setLastInput] = useState<TLastInput>(initial as TLastInput)
 
   return (
     <LastInputContext.Provider value={{ lastInput, setLastInput }}>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,4 +1,4 @@
-import { ComponentProperties } from './api/generated'
+import { ComponentProperties, Multiflash } from './api/generated'
 
 export type TComponentProperty = ComponentProperties & {
   id: string
@@ -18,10 +18,6 @@ export type TComponentRatio = {
   id: string
   ratio: string
 }
-
-export type TFeedUnit = 'kg/d' | 'Sm3/d'
-
-export type TFeedFlow = { unit: TFeedUnit; value: number }
 
 /**
  * Note: Fluids are stored in local storage using type TPackage[]. Updating this type definition may therefore cause the application to break in unexpected ways. To avoid that, remember to increment the version number given to useLocalStorage.
@@ -45,3 +41,5 @@ export type TPackageDialog = {
 }
 
 export type TCalcStatus = 'calculating' | 'done' | 'failure' | undefined
+
+export type TLastInput = Multiflash & { cubicFeedFlow: number }


### PR DESCRIPTION
## Why is this pull request needed?
Status banner needs to know input temperature to give correct state (liquid/solid) of mercury phase (if present).

## What does this pull request change?
Adds a context for the last input entered.

## Issues related to this change:
Closes #323