### PR TITLE
Fix/zero component bug

### DIFF
--- a/api/src/entities/Multiflash.py
+++ b/api/src/entities/Multiflash.py
@@ -35,11 +35,11 @@ class Multiflash(BaseModel):
         }
 
     @validator("component_composition")
-    def validate_composition(cls, v):
-        ids = list(v.keys())
+    def validate_composition(cls, component_composition):
+        ids = list(component_composition.keys())
         if not set(ids) <= set(COMPONENTS.keys()):
             raise ValueError("component_id input contains unknown component!")
-        return v
+        return {k: v for k, v in component_composition.items() if v != 0}
 
     @property
     def component_ids(self) -> List[str]:

--- a/api/src/tests/unit/entities/test_multiflash.py
+++ b/api/src/tests/unit/entities/test_multiflash.py
@@ -71,3 +71,20 @@ def test_multiflash_compute(multiflash_input: dict, multiflash_expected_result: 
     multiflash_result: MultiflashResult = multiflash.compute()
     print(f"Multiflash finished: {timer() - start}")
     assert multiflash_result == multiflash_expected_result
+
+
+@pytest.mark.parametrize(
+    "multiflash_input, multiflash_expected_result",
+    [
+        (MultiflashInput.case_1, MultiflashEntityOutput.case_1),
+    ],
+)
+def test_multiflash_compute_zero_component(multiflash_input: dict, multiflash_expected_result: MultiflashResult):
+    multiflash = Multiflash(**multiflash_input)
+    multiflash_input["component_composition"]["809"] = 0.0
+    multiflash_with_zero = Multiflash(**multiflash_input)
+
+    multiflash_result: MultiflashResult = multiflash.compute()
+    multiflash_result_with_zero = multiflash_with_zero.compute()
+
+    assert multiflash_result == multiflash_result_with_zero == multiflash_expected_result


### PR DESCRIPTION
## Why is this pull request needed?
A bug was discovered in which components with a value of zero affected the computation result (it should not).

## What does this pull request change?
Makes it so that the validation function for component_composition filters out components having a value of zero.

## Issues related to this change:
Forgot to create one ...