### PR TITLE
ci: add dependency groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: "monthly"
+    group:
+      back-end:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/web/"
     open-pull-requests-limit: 100
     schedule:
       interval: "monthly"
+    group:
+      front-end:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Why is this pull request needed?

Add groups to dependabot so that PRs created by dependabot is grouped together.
