### PR TITLE
fix: install poetry without dev

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -60,6 +60,6 @@ COPY ./src .
 USER 1000
 
 FROM base AS prod
-RUN poetry install --no-dev
+RUN poetry install --only=main
 COPY ./src .
 USER 1000


### PR DESCRIPTION
## Why is this pull request needed?

CI unable to use --no-dev flag

## What does this pull request change?

replace with --only=main

## Issues related to this change: