### PR TITLE
ci: run workflow on release please pr updated

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -1,11 +1,7 @@
-name: "On push to branches"
+name: "On PR updated"
 on:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
-    tags-ignore:
-      - v*
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   tests:


### PR DESCRIPTION
## Why is this pull request needed?

Release please does not tigger a workflow run, which is required by branch protection

## What does this pull request change?

Make workflow trigger on reopen etc.

## Issues related to this change: