### PR TITLE
fix: reduce the number of worker connections

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ include                     /etc/nginx/modules-enabled/*.conf;
 
 events {
     multi_accept            on;
-    worker_connections      65535;
+    worker_connections      8192;
 }
 
 http {


### PR DESCRIPTION
## Why is this pull request needed?

Radix reports critical usage on the proxy (nginx)

## What does this pull request change?

Reduce from 65535 -> 8192

## Issues related to this change: