### PR TITLE
ci: Use GitHub app for PAT generation

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -33,14 +33,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linting-and-checks, tests]
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
     outputs:


### PR DESCRIPTION
## Why is this pull request needed?
Automate release-please tokens. 
## What does this pull request change?
No longer uses Personal access tokens, but tokens from a GitHub App.
## Issues related to this change:
