### PR TITLE
ci: update codeowners to Team Hermes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @equinor/mercury
+* @equinor/team-hermes


### PR DESCRIPTION
## What does this pull request change?
Changes the codeowners to `team-hermes` instead of old `mercury` team
