### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -25,7 +25,6 @@ env:
   OAUTH_AUTH_SCOPE: api://0cd10735-a40c-4ff6-84c8-74e3b54ed93f/api
   NGINX_IMAGE: ghcr.io/equinor/mercury-nginx
   API_IMAGE: ghcr.io/equinor/mercury-api
-  LIBHG_VERSION: v2.0.0
 
 jobs:
   build-and-publish-nginx:
@@ -132,6 +131,6 @@ jobs:
           cache-from: type=registry,ref=${{ env.API_IMAGE }}:latest
           cache-to: type=inline
           build-args: |
-            LIBHG_VERSION=${{ env.LIBHG_VERSION }}
+            LIBHG_VERSION=${{ vars.LIBHG_VERSION }}
           secrets: |
             libhg-pat=${{ secrets.LIBHG_PAT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   API_IMAGE: ghcr.io/equinor/mercury-api
-  LIBHG_VERSION: v2.0.0
 
 jobs:
   test-api:
@@ -41,7 +40,7 @@ jobs:
           tags: mercury-api-ci
           cache-from: type=registry,ref=${{ env.API_IMAGE }}:latest
           build-args: |
-            LIBHG_VERSION=${{ env.LIBHG_VERSION }}
+            LIBHG_VERSION=${{ vars.LIBHG_VERSION }}
           secrets: |
             libhg-pat=${{ secrets.LIBHG_PAT }}
 


### PR DESCRIPTION
## Why is this pull request needed?

POOL WEEK.

## What does this pull request change?

- uses docker actions instead of shell scripts
- sets `LIBHG_VERSION` as repository variable (ensures it is consistent across all workflows)
- removes `IMAGE_REGISTRY` variable: We only use ghcr anyways.

## Issues related to this change:
Closes #698
