### PR TITLE
ci: disable docker build summary

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: "Setup: Build API test image"
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: ./api
           target: development


### PR DESCRIPTION
## Why is this pull request needed?

No need for build summary for docker build used for tests.
