### PR TITLE
fix(web): feed flow input does not accept decimals or exponentials

### DIFF
--- a/web/src/feature/calculation_input/FeedFlowInput.test.tsx
+++ b/web/src/feature/calculation_input/FeedFlowInput.test.tsx
@@ -77,4 +77,30 @@ describe('FeedFlowInput', () => {
     fireEvent.blur(input)
     expect(input).toHaveValue('1000')
   })
+
+  test('does not propagate whitespace-only input as 0', () => {
+    const { input, setCubicFeedFlow } = renderFeedFlowInput()
+    typeInto(input, '   ')
+    expect(setCubicFeedFlow).not.toHaveBeenCalled()
+  })
+
+  test('does not propagate Infinity', () => {
+    const { input, setCubicFeedFlow } = renderFeedFlowInput()
+    typeInto(input, 'Infinity')
+    expect(setCubicFeedFlow).not.toHaveBeenCalled()
+  })
+
+  test('reverts whitespace-only input on blur', () => {
+    const { input } = renderFeedFlowInput({ cubicFeedFlow: 1000 })
+    typeInto(input, '   ')
+    fireEvent.blur(input)
+    expect(input).toHaveValue('1000')
+  })
+
+  test('reverts Infinity on blur', () => {
+    const { input } = renderFeedFlowInput({ cubicFeedFlow: 1000 })
+    typeInto(input, 'Infinity')
+    fireEvent.blur(input)
+    expect(input).toHaveValue('1000')
+  })
 })

--- a/web/src/feature/calculation_input/FeedFlowInput.tsx
+++ b/web/src/feature/calculation_input/FeedFlowInput.tsx
@@ -1,5 +1,5 @@
 import { Switch, TextField } from '@equinor/eds-core-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { molePerStandardCubicMeter } from '../../common/constants'
 
@@ -30,6 +30,13 @@ export const FeedFlowInput = (props: {
   const [inputText, setInputText] = useState<string>(formatDisplayValue(props.cubicFeedFlow))
   const selectedUnit = displayMassFeedFlow ? 'kg/d' : 'Sm3/d'
 
+  useEffect(() => {
+    if (props.molecularWeightSum === undefined && displayMassFeedFlow) {
+      setDisplayMassFeedFlow(false)
+      setInputText(formatDisplayValue(props.cubicFeedFlow))
+    }
+  }, [props.molecularWeightSum, props.cubicFeedFlow, displayMassFeedFlow])
+
   const handleUnitToggle = (checked: boolean) => {
     setDisplayMassFeedFlow(checked)
     const displayValue = checked
@@ -42,8 +49,11 @@ export const FeedFlowInput = (props: {
     const raw = event.target.value
     setInputText(raw)
 
-    const parsed = Number(raw)
-    if (raw !== '' && !Number.isNaN(parsed)) {
+    const trimmed = raw.trim()
+    if (trimmed === '') return
+
+    const parsed = Number(trimmed)
+    if (Number.isFinite(parsed)) {
       if (displayMassFeedFlow) {
         props.setCubicFeedFlow(convertFlowFromMassToCubic(parsed, props.molecularWeightSum ?? 1))
       } else {
@@ -53,8 +63,9 @@ export const FeedFlowInput = (props: {
   }
 
   const handleBlur = () => {
-    const parsed = Number(inputText)
-    if (inputText === '' || Number.isNaN(parsed)) {
+    const trimmed = inputText.trim()
+    const parsed = Number(trimmed)
+    if (trimmed === '' || !Number.isFinite(parsed)) {
       // Revert to the last valid value on blur
       const displayValue = displayMassFeedFlow
         ? convertFlowFromCubicToMass(props.cubicFeedFlow, props.molecularWeightSum ?? 1)


### PR DESCRIPTION
## Problem

The feed flow input field did not accept decimal values (e.g. `1.5`) or exponential notation (e.g. `1e3`). This was caused by the input being a fully controlled `type="number"` field that converted to `Number()` on every keystroke, destroying intermediate typing states like `1.` or `1e`.

Closes #258

## Solution

- Store a **string state** (`inputText`) for the raw display value instead of deriving it from the numeric state on every render
- Only convert to a number and propagate upstream when the input is a valid parseable number
- On **blur**, format the value or revert to the last valid value if the input is incomplete/invalid
- Moved unit toggle sync from a `useEffect` into the toggle handler directly (cleaner and avoids exhaustive-deps lint warning)
- Removed `type="number"` from the `TextField` to allow free-form typing of `.` and `e`

## Changes

- `web/src/feature/calculation_input/FeedFlowInput.tsx` — rewritten input handling
- `web/src/feature/calculation_input/FeedFlowInput.test.tsx` — new test file with 9 tests covering decimals, exponentials, intermediate states, blur formatting, and empty input revert