### PR TITLE
fix(api): handle expired JWT gracefully without traceback

### DIFF
--- a/api/src/authentication/authentication.py
+++ b/api/src/authentication/authentication.py
@@ -57,7 +57,7 @@ def auth_with_jwt(jwt_token: str = Security(oauth2_scheme)) -> User:
             user = User(user_id=payload["sub"], **payload)
     except jwt.exceptions.InvalidTokenError as error:
         logger.warning(f"Failed to decode JWT: {error}")
-        raise UnauthorizedException from error
+        raise UnauthorizedException from None
 
     if user is None:
         raise UnauthorizedException

--- a/api/src/common/exceptions.py
+++ b/api/src/common/exceptions.py
@@ -36,6 +36,7 @@ class ApplicationException(Exception):
         status: int = 500,
         severity: ExceptionSeverity = ExceptionSeverity.ERROR,
     ):
+        super().__init__(message)
         self.status = status
         self.type = self.__class__.__name__
         self.message = message
@@ -104,5 +105,5 @@ class UnauthorizedException(ApplicationException):
         debug: str = "Token was not valid for requested operation.",
         extra: dict[str, Any] | None = None,
     ):
-        super().__init__(message, debug, extra, status.HTTP_401_UNAUTHORIZED)
+        super().__init__(message, debug, extra, status.HTTP_401_UNAUTHORIZED, severity=ExceptionSeverity.WARNING)
         self.type = self.__class__.__name__

--- a/web/src/api/generated/core/OpenAPI.ts
+++ b/web/src/api/generated/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '1.1.6',
+    VERSION: '1.1.8',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/web/src/api/generated/models/ValidationError.ts
+++ b/web/src/api/generated/models/ValidationError.ts
@@ -6,5 +6,7 @@ export type ValidationError = {
     loc: Array<(string | number)>;
     msg: string;
     type: string;
+    input?: any;
+    ctx?: Record<string, any>;
 };
 


### PR DESCRIPTION
## Problem

When a user opens the app with an expired JWT, the API logs an ugly full traceback instead of a clean warning:

```
Traceback (most recent call last):
  File "/code/src/authentication/authentication.py", line 49, in auth_with_jwt
    payload: dict[str, Any] = jwt.decode(...)
  ...
jwt.exceptions.ExpiredSignatureError: Signature has expired

The above exception was the direct cause of the following exception:
  ...
common.exceptions.UnauthorizedException
```

Expired tokens are a normal occurrence and should not produce error-level logs with full tracebacks.

## Changes

- **`UnauthorizedException` severity → `WARNING`**: The `generic_exception_handler` now calls `logger.warning()` instead of `logger.exception()`, so no traceback is printed for auth failures.
- **`raise from None`** instead of `raise from error` in `authentication.py` for JWT decode errors: Suppresses exception chaining, matching the pattern already used for signing key errors on the line above.

## Result

With an expired JWT, the log output is now:

```
WARNING:  Failed to decode JWT: Signature has expired
WARNING:  Token validation failed
```
