### PR TITLE
fix(api): use TestClient context manager for proper ASGI lifespan handling in tests

### DIFF
--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -1,6 +1,6 @@
 # Fixtures for integration tests
 
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 
 import jwt
 import pytest
@@ -15,12 +15,11 @@ from config import config
 
 
 @pytest.fixture(scope="function")
-def test_app() -> TestClient:
+def test_app() -> Generator[TestClient]:
     app = create_app()
-    client = TestClient(app=app)
-
     app.dependency_overrides[auth_with_jwt] = _mock_auth_with_jwt
-    return client
+    with TestClient(app=app) as client:
+        yield client
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary

Use the `TestClient` context manager with `yield` in the `test_app` fixture to ensure proper ASGI lifespan handling.

## Changes

In `api/tests/integration/conftest.py`:
- Wrap `TestClient` in a `with` statement so ASGI startup/shutdown lifespan events fire correctly
- Use `yield` instead of `return` so the client is properly closed after each test
- Move `dependency_overrides` setup before client creation for clarity

Closes #741