### PR TITLE
chore: use up to date ruff codes

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -20,7 +20,14 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pre-commit>=4.5.1", "pytest>=9.0", "ruff>=0.14.13", "mypy>=1.14.1", "mkdocs-techdocs-core>=1.4", "types-cachetools>=6.2.0.20251022"]
+dev = [
+  "pre-commit>=4.5.1",
+  "pytest>=9.0",
+  "ruff>=0.14.13",
+  "mypy>=1.14.1",
+  "mkdocs-techdocs-core>=1.4",
+  "types-cachetools>=6.2.0.20251022",
+]
 
 [tool.uv]
 package = false
@@ -64,7 +71,7 @@ select = [
   "FURB", # refurb (modern Python idioms)
   "PLC",  # pylint conventions
   "PLE",  # pylint errors
-  "TCH",  # flake8-type-checking (move type-only imports behind TYPE_CHECKING)
+  "TC",   # flake8-type-checking (move type-only imports behind TYPE_CHECKING)
   "FA",   # flake8-future-annotations
   "ISC",  # flake8-implicit-str-concat
   "RSE",  # flake8-raise
@@ -81,11 +88,11 @@ ignore = [
   "SIM102",  # collapsible-if (sometimes nested ifs are more readable)
   "PLC0415", # import-outside-top-level (intentional lazy imports in app factory/CLI)
   "N818",    # exception name Error suffix (ApplicationException is established naming)
-  "PT003"    # Nice to have explicit fixture scope
+  "PT003",   # Nice to have explicit fixture scope
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]  # assert usage is expected in tests
+"tests/**" = ["S101"] # assert usage is expected in tests
 
 [tool.ruff.lint.isort]
 extra-standard-library = ["libhg"]


### PR DESCRIPTION

## Why is this pull request needed?

Pool week

## What does this pull request change?

TCH was renamed to TC in ruff. 

## Issues related to this change:
None.
