### PR TITLE
chore: clean up Docker config

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,7 +15,6 @@ RUN gh release download ${LIBHG_VERSION} \
 
 FROM python:3.13-slim-bookworm AS base
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ENV UV_VERSION="0.9.22"
 ENV USER="mercury"
 ENV PYTHONPATH=/code/src
 
@@ -36,9 +35,7 @@ ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy \
   UV_PYTHON_DOWNLOADS=never \
   UV_TOOL_BIN_DIR=/usr/local/bin
-RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install --upgrade pip && \
-  pip install "uv==$UV_VERSION"
+COPY --from=ghcr.io/astral-sh/uv:0.9.22 /uv /usr/local/bin/uv
 
 
 WORKDIR /code

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -2,6 +2,8 @@ services:
   api:
     build:
       target: development
+      cache_from:
+        - ghcr.io/equinor/mercury-api:latest
     image: mercury-api-ci
     environment:
       ENVIRONMENT: local

--- a/compose.yml
+++ b/compose.yml
@@ -13,8 +13,6 @@ services:
     restart: unless-stopped
     build:
       context: api
-      cache_from:
-        - ghcr.io/equinor/mercury-api:latest
       args:
         LIBHG_VERSION: $LIBHG_VERSION
       secrets:


### PR DESCRIPTION
## What does this pull request change?

- **Replace pip-installed uv with `COPY` from official image** — Instead of `pip install uv`, copies the pre-built binary directly from `ghcr.io/astral-sh/uv:0.9.22`. This is faster, produces a smaller layer, and removes the pip dependency entirely.
- **Move `cache_from` from `compose.yml` to `compose.ci.yml`** — `cache_from` pulls cache metadata from GHCR, which requires authentication. This causes a harmless but noisy error locally (`ERROR [api] importing cache manifest from ghcr.io/equinor/mercury-api:latest`). Since it's only useful in CI contexts, it belongs in `compose.ci.yml`.