### PR TITLE
build: harden against supply-chain attacks

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       "version": "lts",
       "installYarnUsingApt": false
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {"moby": false}
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       "version": "lts",
       "installYarnUsingApt": false
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {"moby": false}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": { "moby": false }
   },
   "customizations": {
     "vscode": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/api"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       back-end:
         update-types:
@@ -14,6 +16,8 @@ updates:
     directory: "/web/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       front-end:
         update-types:
@@ -24,6 +28,8 @@ updates:
     directory: ".github/workflows"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directories:
@@ -31,6 +37,8 @@ updates:
       - "/api"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       dockerfile:
         update-types:
@@ -41,6 +49,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       pre-commit:
         patterns:

--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup: radix CLI (RX)"
-        uses: equinor/radix-github-actions@v2
+        uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2
 
       - name: "Run: Validate radix config"
         run: rx validate radix-config
@@ -49,10 +49,10 @@ jobs:
     needs: [validate]
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup: radix CLI (RX)"
-        uses: equinor/radix-github-actions@v2
+        uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2
         with:
           azure_client_id: ${{ env.AZURE_CLIENT_ID }}
 

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -22,10 +22,10 @@ jobs:
             task: lint-typescript-compilation
     steps:
       - name: "Setup: Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup: install mise"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: "Run: ${{ matrix.title }}"
         run: mise run ${{ matrix.task }}

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -39,12 +39,12 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -31,20 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           fetch-tags: true
 
       - name: "Setup: login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Setup: set up Docker Buildx"
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: "Setup: get version info"
         id: version
@@ -67,7 +67,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: "Run: build and publish nginx"
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ./web
           target: nginx-prod
@@ -86,20 +86,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           fetch-tags: true
 
       - name: "Setup: login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Setup: set up Docker Buildx"
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: "Setup: get version info"
         id: version
@@ -122,7 +122,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: "Run: build and publish API"
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ./api
           target: prod

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,23 +19,23 @@ jobs:
     name: "Tests: API"
     steps:
       - name: "Setup: Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup: install mise"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: "Setup: Login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Setup: set up Docker Buildx"
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: "Setup: Build API test image"
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -60,10 +60,10 @@ jobs:
     name: "Tests: Web"
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "Setup: install mise"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: "Run: Tests with yarn"
         run: mise run test-web-unit

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /code
 USER "node"
 COPY --chown="node:node" package.json yarn.lock ./
 RUN --mount=type=cache,target=$YARN_CACHE_FOLDER,uid=1000 \
-  yarn install
+  yarn install --frozen-lockfile
 
 COPY --chown="node:node" public public
 COPY --chown="node:node" tsconfig.json vite.config.mts index.html ./


### PR DESCRIPTION
## Summary

Hardens the project against supply-chain attacks across three areas.

### Pin GitHub Actions to commit SHAs

All external `uses:` references in CI workflows are now pinned to their full commit SHA, with the version tag preserved as a comment. This prevents tag-mutation attacks where a malicious actor could overwrite a tag to point to a different commit.

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `jdx/mise-action` | v4 | `1648a781` |
| `docker/login-action` | v4 | `4907a6dd` |
| `docker/setup-buildx-action` | v4 | `4d04d5d9` |
| `docker/build-push-action` | v7 | `bcafcacb` |
| `actions/create-github-app-token` | v3 | `bcd2ba49` |
| `googleapis/release-please-action` | v5 | `45996ed1` |
| `equinor/radix-github-actions` | v2 | `b23674a5` |

Dependabot is already configured for `github-actions` updates and will automatically open PRs to keep the pinned SHAs current.

### Add 7-day cooldown to Dependabot

All five Dependabot ecosystems (`uv`, `npm`, `github-actions`, `docker`, `pre-commit`) now have a `cooldown: default-days: 7`. This provides a buffer period before Dependabot proposes updates, reducing the risk of automatically adopting a freshly-released malicious version.

### Enforce lockfile usage

- **`web/Dockerfile`**: `yarn install` → `yarn install --frozen-lockfile` (the API Dockerfile already used `uv sync --locked`)

### Devcontainer fixes

- Set `moby: false` on the `docker-in-docker` feature to use the standard Docker Engine instead of Moby
- Added `devcontainer-lock.json` lockfile to pin devcontainer feature versions