### PR TITLE
build: generate API client from source instead of a running server

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ yarn compile                     # TypeScript type check (tsc --noEmit)
 yarn lint                        # Biome lint + format check
 yarn test run                    # Run vitest unit tests
 yarn build                       # Production build (tsc + vite build → web/build/)
-yarn generate                    # Regenerate API client (requires API on port 5000)
+yarn generate                    # Regenerate API client (exports schema from source; no running API needed)
 ```
 
 ### API (`api/` directory)
@@ -146,7 +146,7 @@ Routes are split into authenticated (JWT via Microsoft Entra ID) and public, reg
 
 - **Commits**: Follow [Conventional Commits](https://www.conventionalcommits.org/). Prefixes: `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`. Enforced by pre-commit.
 - **Versioning**: Managed by `release-please`. Version tracked in `api/src/cli/__about__.py`, `api/src/app.py`, and `web/package.json`. Do NOT manually bump versions.
-- **Generated code**: `web/src/api/generated/` is auto-generated from the OpenAPI schema. Never edit directly. Regenerate with `yarn generate` (requires API running on port 5000).
+- **Generated code**: `web/src/api/generated/` is auto-generated from the OpenAPI schema. Never edit directly. Regenerate with `yarn generate` (the schema is exported directly from `create_app().openapi()` via `api/scripts/export_openapi.py`, so no running API is required).
 - **Python style**: 120 char line length, ruff for linting/formatting, type hints required. `libhg` is treated as a standard library import for isort.
 - **TypeScript style**: Biome — spaces for indent, single quotes, trailing commas (ES5), no semicolons. Generated files excluded from linting.
 - **Deployment**: Radix (Equinor Kubernetes PaaS). Config in `radixconfig.yaml`. Two environments: `dev` (auto-deploy from main) and `prod` (deploy on release).

--- a/.mise/tasks/lint.toml
+++ b/.mise/tasks/lint.toml
@@ -1,7 +1,7 @@
 [lint-ruff]
 description = "Run ruff linter"
 depends = ["install-api-dependencies"]
-run = ["uv run ruff check --fix --exit-zero", "uv run ruff format"]
+run = ["uv run ruff check --fix", "uv run ruff format"]
 
 [lint-mypy]
 description = "Run mypy linter on the api"

--- a/.mise/tasks/utilities.toml
+++ b/.mise/tasks/utilities.toml
@@ -8,4 +8,8 @@ echo "Virtual Environment: $VIRTUAL_ENV"
 [generate-api-types]
 description = "Generate API types for typescript"
 dir = "{{ config_root }}/web"
-run = "yarn generate"
+run = '''
+(cd ../api && uv run python scripts/export_openapi.py "{{ config_root }}/web/openapi.json")
+CI=true yarn generate
+rm -f openapi.json
+'''

--- a/api/scripts/export_openapi.py
+++ b/api/scripts/export_openapi.py
@@ -1,0 +1,28 @@
+"""Export the OpenAPI schema directly from the application source.
+
+This avoids having to run the API server (or Docker) just to obtain the schema.
+Usage:
+    python scripts/export_openapi.py <output_path>
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python scripts/export_openapi.py <output_path>")
+
+    # Make the application package importable without relying on PYTHONPATH.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+    from app import create_app
+
+    output_path = Path(sys.argv[1])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        json.dump(create_app().openapi(), f)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/src/entities/multiflash.py
+++ b/api/src/entities/multiflash.py
@@ -1,4 +1,3 @@
-import libhg
 from collections.abc import Mapping
 
 import numpy as np
@@ -95,6 +94,8 @@ class Multiflash(BaseModelWrapper):
         }
 
     def compute(self) -> MultiflashResult:
+        import libhg
+
         # Need to normalize feed composition for phase_fraction to not be NaN:
         normalized_feed_composition = self.normalized_feed_composition
         (

--- a/api/src/features/metrics/metrics_feature.py
+++ b/api/src/features/metrics/metrics_feature.py
@@ -17,5 +17,4 @@ router = APIRouter(tags=["metrics"], route_class=ExceptionHandlingRoute)
 )
 async def get() -> str:
     """Return metrics for application."""
-    response = cast("str", get_metrics_use_case())
-    return response
+    return cast("str", get_metrics_use_case())

--- a/web/src/api/generate-api-pre-commit.sh
+++ b/web/src/api/generate-api-pre-commit.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
-set -e -o pipefail
+set -euo pipefail
 
-PATTERN="api/src/features/*"
-PATTERN+="|api/src/entities/*"
-PATTERN+="|api/src/common/*"
-PATTERN+="|api/src/authentication/*"
+# Regenerate the API client from the application source and fail if the
+# committed client drifts from it. Capturing the working-tree state before and
+# after generation lets this run identically in local pre-commit and in CI
+# (where nothing is staged), without relying on staged-file detection.
 
-CHANGED_API_FILES=()
-while read -r; do
-	CHANGED_API_FILES+=("$REPLY")
-done < <(git diff --name-only --cached --diff-filter=ACMR | grep -E "$PATTERN")
+# Record the repository state before generation.
+git_status_before=$(git status --porcelain)
 
-if [ ${#CHANGED_API_FILES[@]} -eq 0 ]; then
-	echo "No changes in API relevant files. No need to generate API."
+openapi_path="${PWD}/web/openapi.json"
+# Export the OpenAPI schema directly from the application source.
+# This does not require a running API server (or Docker).
+(cd api && uv run python scripts/export_openapi.py "$openapi_path")
+
+cd web
+# CI=true forces Kubb to use a plain logger compatible with non-TTY environments
+CI=true yarn generate
+rm -f openapi.json
+cd ..
+
+echo "API Client successfully generated"
+
+# Record the repository state after generation and fail on any drift.
+git_status_after=$(git status --porcelain)
+
+if [ "$git_status_before" = "$git_status_after" ]; then
+	echo "API client is up to date."
+	exit 0
 else
-	echo "Changes detected in API relevant files. Generating API ..."
-	openapi_path="${PWD}/web/openapi.json"
-	# Export the OpenAPI schema directly from the application source.
-	# This does not require a running API server (or Docker).
-	(cd api && uv run python scripts/export_openapi.py "$openapi_path")
-	cd web
-	# CI=true forces Kubb to use a plain logger compatible with non-TTY environments
-	CI=true yarn generate
-	rm -f openapi.json
-	echo "API Client successfully generated"
+	echo "API client is out of date. Re-run generation and commit the changes:"
+	git --no-pager diff --stat
+	exit 1
 fi

--- a/web/src/api/generate-api-pre-commit.sh
+++ b/web/src/api/generate-api-pre-commit.sh
@@ -15,11 +15,10 @@ if [ ${#CHANGED_API_FILES[@]} -eq 0 ]; then
 	echo "No changes in API relevant files. No need to generate API."
 else
 	echo "Changes detected in API relevant files. Generating API ..."
-	# This requires the API to be running on localhost port 5000
-	if ! curl -sf http://localhost:5000/openapi.json -o web/openapi.json; then
-		echo "Failed to reach API at localhost:5000. Is it running?"
-		exit 1
-	fi
+	openapi_path="${PWD}/web/openapi.json"
+	# Export the OpenAPI schema directly from the application source.
+	# This does not require a running API server (or Docker).
+	(cd api && uv run python scripts/export_openapi.py "$openapi_path")
 	cd web
 	# CI=true forces Kubb to use a plain logger compatible with non-TTY environments
 	CI=true yarn generate

--- a/web/src/api/generated/types/User.ts
+++ b/web/src/api/generated/types/User.ts
@@ -20,6 +20,7 @@ export type User = {
     */
     roles?: string[];
     /**
+     * @default 2
      * @type integer | undefined
     */
     scope?: AccessLevel;


### PR DESCRIPTION
## What

Regenerate the TypeScript API client from the application source instead of requiring a running API server (or Docker), and make CI fail when the committed client drifts.

- Add `api/scripts/export_openapi.py`, which exports the schema directly from `create_app().openapi()`.
- Make the `libhg` import in `api/src/entities/multiflash.py` lazy (inside `compute()`), so the app can be imported without the Fortran binary present. `libhg` is only needed at compute time, not at schema-generation time.
- Rewrite the `generate-api-client` pre-commit hook to always regenerate from source and compare the working-tree state before and after, failing on any difference. This makes drift detection work identically in local pre-commit and in CI (under `prek run --all-files`), instead of relying on staged-file detection that never triggers on a fresh CI checkout.
- Update the `generate-api-types` mise task to use the source-based export (no `curl http://localhost:5000/openapi.json`).
- Enforce ruff failures in CI by dropping `--exit-zero` from the `lint-ruff` task, and fix the RET504 violation it surfaced in `metrics_feature.py`.
- Refresh the (stale) generated client (`User.ts` gains the `@default 2` it was missing).
- Update `copilot-instructions.md` accordingly.

## Why

Previously the client could only be regenerated against a live API on port 5000, which made local/CI codegen awkward and Docker-dependent. Additionally, the old hook keyed off staged files, so it never ran in a fresh CI checkout — a stale client could pass CI. Exporting from source removes the running-API coupling, and the before/after drift check closes the CI gap.

## Verification

- `uv run python scripts/export_openapi.py <out>` produces a valid OpenAPI 3.1 schema with all routes — no server, Docker, or libhg required.
- `mise run generate-api-types` and the pre-commit hook both regenerate the client successfully.
- Drift check confirmed: an up-to-date client exits 0; a schema change (e.g. an `operation_id` edit) makes the hook exit 1 with a diff of the stale generated files.
- `prek run --all-files`, `mypy src`, and `yarn compile` all pass.